### PR TITLE
A formal request for code channel access

### DIFF
--- a/avatar - four nations restored/common/cultures/00_cultures.txt
+++ b/avatar - four nations restored/common/cultures/00_cultures.txt
@@ -10,55 +10,10 @@ earth_kingdom_culture = {
 		color = { 34 120 30 }
 		
 		male_names = {
-			Abaoji_Abaoji Aiwei_Aiwei Akisada_Akisada Akitakai_Akitaka Akitsune_Akitsune Alp_Alp Anxi_Anxi Ao-Bang_Ao-Bang 
-			Ao_Ao Aoda_Aoda Arik_Arik Baatar_Baatar Bai-Kong_Bai-Kong Bai_Bai Bang_Bang Bei_Bei 
-			Biegute_Biegute Bishe_Bishe Blush_Blush Bo-Bee_Bo-Bee Bo-Bi_Bo-Bi Bo-Bo_Bo-Bo Bo-Lee_Bo-Lee Bo-Rei_Bo-Rei 
-			Bo_Bo Bohai_Bohai Bolin_Bolin Brei-Dee_Brei-Dee Bumi_Bumi Bushi_Bushi Butakha_Butakha Buwei_Buwei 
-			Cao-Cao_Cao-Cao Cao-Dee_Cao-Dee Cao_Cao Chanai_Chanai Changdong_Changdong Chao_Chao Cheng_Cheng Chin_Chin 
-			Chong_Chong Chow_Chow Chung_Chung Cong_Cong Da-Lee_Da-Lee Da_Da Dai-Lee_Dai-Lee Dai_Dai 
-			Daquan_Daquan Dashi_Dashi Daw_Daw Deguang_Deguang Deming_Deming Dilie_Dilie Dong-Long_Dong-Long Dong-Min_Dong-Min 
-			Dong_Dong Du-Ho_Du-Ho Duolubu_Duolubu Eh-Dee_Eh-Dee Fai_Fai Fang_Fang Fei_Fei Feng-Long_Feng-Long 
-			Feng_Feng Fong_Fong Fu_Fu Fugazhi_Fugazhi Fuguzhi_Fuguzhi Fuling-Ji_Fuling-Ji Fuling_Fuling Fung_Fung 
-			Gai-Ree_Gai-Ree Ganbat_Ganbat Gang_Gang Gansu_Gansu Gao_Gao Gaye_Gaye Ghazan_Ghazan Godan_Godan 
-			Gommu_Gommu Gopala_Gopala Gorota_Gorota Gou'er_Gou'er Gow_Gow Gsi_Gzi Guang_Guang Gun_Gun 
-			Guo_Guo Hai_Hai Harghasun_Harghasun Harjjaravarman_Harjjaravarman Haru_Haru Haruie_Haruie Harumasa_Harumasa He-Long_He-Long 
-			He_He Heng_Heng Hiroshi_Hiroshi Ho-Tun_Ho-Tun Ho_Ho Hokai_Hokai Hong-Lee_Hong-Li Hong_Hong 
-			Hongji_Hongji Hougu_Hougu How_How Hu-Hai_Hu-Hai Huan_Huan Hung_Hung Hyo_Hyo Hyuga_Hyuga 
-			Hyun_Hyun Ieharu_Ieharu Iemune_Iemune Jae_Jae Jai-Ree_Jai-Ree Jai_Jai Jebe_Jebe Jet_Jet 
-			Ji-Jia_Ji-Jia Ji_Ji Jia_Jia Jian_Jian Jiao-Long_Jiao-Long Jie_Jie Jin-Wei_Jin-Wei Jin_Jin 
-			Jing_Jing Jingbo_Jingbo Jochi_Jochi Ju-Long_Ju-Long Ju-Min_Ju-Min Ju-Wei_Ju-Wei Ju-si_Ju-si Ju_Ju 
-			Jung_Jung Juno_Juno Kai_Kai Kaili_Kaili Kang-Cong_Kang-Cong Kang_Kang Kanto_Kanto Karu_Karu 
-			Kasuki_Kazuki Kei-See_Kei-See Kenji_Kenji Ketuyu_Ketuyu Keung_Keung Khal_Khal Ki_Ki Kim-Lee_Kim-Lee 
-			Kim_Kim Kokochu_Kokochu Kong_Kong Kopti_Kopti Kosa_Koza Kosel_Kozel Kuei_Kuei Kun_Kun 
-			Kuo-Yin_Kuo-Yin Kuo_Kuo Kuon_Kuon Kwan_Kwan Lao_Lao Laquan_Laquan Lee-Min_Lee-Min Lee-Shen_Lee-Shen 
-			Lee-Wei_Lee-Wei Lee_Lee Lei_Lei Li_Li Liang_Liang Lin-Yee_Lin-Yee Liu_Liu Long-Cheng_Long-Cheng 
-			Long-Dong_Long-Dong Long-Fai_Long-Fai Long-Fei_Long-Fei Long-Feng_Long-Feng Long-Shen_Long-Shen Long_Long Lu_Lu Lun-Quing_Lun-Quing 
-			Lun_Lun Luu-Kass_Luu-Kass Macao_Macao Mako_Mako Malu_Malu Mang_Mangokpok Masaharu_Masaharu Masanobu_Masanobu 
-			Megujin_Megujin Menggei_Menggei Min-Ho_Min-Ho Min-Ki_Min-Ki Min_Min Ming_Ming Moku_Moku Muneie_Muneie 
-			Muneuji_Muneuji Na_Na Nayaga_Nayaga Nobumaza_Nobumasa Nobuyasu_Nobuyasu Nogai_Nogai Noritame_Noritame Odchigin_Odchigin 
-			Oh_Oh Ohev_Ohev Okhotur_Okhotur Onku_Onku Otaku_Otaku Oyaji_Oyaji Pao_Pao Peng-Bo_Peng-Bo 
-			Peng-Lun_Peng-Lun Peng_Peng Ping-Bai_Ping-Bai Ping_Ping Poi_Poi Pong_Pong Pu-On-Tim_Pu-On-Tim Qi-Fu_Qi-Fu 
-			Qi_Qi Qian_Qian Qin_Qin Qing_Qing Quon_Quon Raiko_Raiko Ratnapala_Ratnapala Rian_Rian 
-			Ro-Bi_Ro-Bi Roi_Roi Ru_Ru Ruan-Jiang_Ruan-Jiang Ruan_Ruan Ryan_Ryan Ryu_Ryu Saikhan_Saikhan 
-			San_San Sang-Kyu_Sang-Kyu Sang-Min_Sang-Min Saru_Saru Satoru_Satoru Sensu_Sensu Sha-Wan_Sha-Wan She-Fu_She-Fu 
-			She-Tao_She-Tao She_She Shen-Fu_Shen-Fu Shen-Long_Shen-Long Shen-Ping_Shen-Ping Shen-Qi_Shen-Qi Shen-Ru_Shen-Ru Shen_Shen 
-			Sheng-She_Sheng-She Sheng_Sheng Shilugu_Zhilugu Shin_Shin Shinji_Shinji Shiro_Shiro Shu_Shu Si_Si 
-			Sokal_Sokal Songyuan_Zhongyuan Songzen_Songzan Sotan_Sotan Stei-Fen_Stei-Fen Su_Su Sud_Sud Sung_Sung 
-			Suogu_Suogu Suyiketu_Suyiketu Swami_Swami Tahn_Tahn Tamenori_Tamenori Tao-Long_Tao-Long Tao-Xia_Tao-Xia Tao_Tao 
-			Temujin_Temujin Temur_Temur Teo_Teo Tian-Wei_Tian-Wei Tian_Tian Tiande_Tiande Todogen_Todogen Tolui_Tolui 
-			Tong_Tong Toza_Toza Tsuneaki_Tsuneaki Tu_Tu Tugor_Tugor Tumen_Tumen Tycho_Tycho Tyro_Tyro 
-			Uge_Uge Uji_Ujimune Ukhuna_Ukhuna Usluk_Uzluk Usur_Uzur Vijaya_Vijaya Wan_Wan Wang-Long_Wang-Long 
-			Wang_Wang Wei-Jin_Wei-Jin Wei-Li_Wei-Li Wei_Wei Wen_Wen Wenshunu_Wenshunu Wing_Wing Wolila_Wolila 
-			Wu_Wu Wuge_Wuge Wuyu_Wuyu Xai-Bau_Xai-Bau Xai_Xai Xian-Lee_Xian-Lee Xian_Xian Xie-Chao_Xie-Chao 
-			Xie-Tao_Xie-Tao Xie_Xie Xin-Fu_Xin-Fu Xin_Xin Xing_Xing Xingke_Xingke Xiuge_Xiuge Xun_Xun 
-			Yanchege_Yanchege Yang-Yu_Yang-Yu Yang_Yang Yanxi_Yanxi Yashi_Yashi Yasunobu_Yasunobu Yedi_Yedi Yegu_Yegu 
-			Yeke_Yeke Yi-Ming_Yi-Ming Yi-Tian_Yi-Tian Yi_Yi Yie-Bei_Yie-Bei Yilie_Yilie Yin-Lee_Yin-Lee Yin-Long_Yin-Long 
-			Yin_Yin Ying-Yu_Ying-Yu Ying_Ying Yoh_Yoh Yong-Fang_Yong-Fang Yong-Min_Yong-Min Yong_Yong Young_Young 
-			Yu-Yu_Yu-Yu Yu_Yu Yuan_Yuan Yun-Lee_Yun-Lee Yun_Yun Yung_Yung Yuu_Yuu Zaheer_Zaheer 
-			Zei_Zei
+			Abaoji Aiwei Akisada Akitakai Akitsune Alp Anxi Ao-Bang
 			Ah Ai Aiguo Aihou Aixing Aman An Anding Ang
 			Anguo Anli Anle Anliang Anmin Anqi Anshi Anyu
-			Ao Asu Ayi Ayu
+			Ao Asu Ayi Ayu Ao Aoda Arik
 			Ba Bai Baihu Ban Bang Bao Baochou Baojian Bei
 			Beidi Beigong Ben Benchu Benli Bi Bian Biao
 			Biecheng Biming Bin Binbo Bing Bingwen
@@ -78,6 +33,9 @@ earth_kingdom_culture = {
 			Boyin Boying Boyou Boyu Boyuan Boyue Bozai
 			Bozhang Bozhao Bozhen Bozhi Bozhong Bozhou
 			Bozhu Bozhuo Bozong Bozu Bu Buwei Buyi
+			Baatar Bai-Kong Bai Bang Bei Biegute Bishe 
+			Blush Bo-Bee Bo-Bi Bo-Bo Bo-Lee Bo-Rei 
+			Bo Bohai Brei-Dee Bumi Bushi Butakha Buwei 
 			Cai Can Cang Cangshu Cao Ce Cen Cha Chai Chan
 			Chanbo Chang Changbo Changchong Changchun
 			Changde Changhua Changji Changjun Changliang
@@ -93,6 +51,9 @@ earth_kingdom_culture = {
 			Chunyu Chuo Chuqi Churen Chushan Chuxu Chuyue
 			Ci Cibo Ciming Ciqing Cisun Ciwen Ciweng
 			Ciyang Cong Congdang Congyi Cui Cuan Cun
+			Cao-Cao Cao-Dee Cao Chanai Changdong Chao Cheng Chin 
+			Chong Chow Chung Cong 
+			Da-Lee Da Dai-Lee Dai Daquan Dashi Daw Deguang Deming Dilie Dong-Long Dong-Min
 			Da Daan Dachun Dafang Daguo Dai Daijia Daiju
 			Daiping Daming Damu Dan Dang Dao Daochu
 			Daoguang Daohe Daozhen Daxun Dayi De Deang
@@ -105,12 +66,16 @@ earth_kingdom_culture = {
 			Diao Digong Ding Dingan Dinggong Dingguo
 			Dingqing Dingzhu Dingzu Disun Dong Dongli
 			Dou Du Duan Dun Dunli Dunxin Duo Duyi
-			E En Ending Enlai Erkang Ertai
+			Dong Du-Ho Duolubu 
+			Eh-Dee E En Ending Enlai Erkang Ertai
+			Feng-Long 
 			Fa Fai Fan Fang Fanglan Fangqing Fangzheng
 			Fangzhi Fei Feixin Fen Feng Fenggao Fengge
 			Fengji Fengqing Fengxian Fengxiao Fengxun
 			Fu Fucheng Fuguo Fuhua Fuling Fulu Fuluan
 			Fuxiang Fuxing Fuxiu Fuxuan Fuyuan
+			Feng Fong Fu Fugazhi Fuguzhi Fuling-Ji Fuling Fung 
+			Gai-Ree Ganbat Gansu Gao Gaye Ghazan Godan
 			Gai Gan Gang Gao Gaoqing Gaotang Ge Geming
 			Gen Geng Gengguo Genju Gong Gonga Gongbi
 			Gongchao Gongda Gongdu Gongfang Gongfen
@@ -131,6 +96,11 @@ earth_kingdom_culture = {
 			Guifen Guiren Guilong Gun Guo Guofan Guofu
 			Guoliang Guoping Guorang Guoshan Guotin
 			Guowei Guoyi Guozhang Guozhi Guozhong Guyan
+			Gommu Gopala Gorota Gou'er Gow Gsi_Gzi Guang Gun Guo Hai 
+			Harghasun Harjjaravarman Haru Haruie Harumasa He-Long 
+			He Heng Hiroshi Ho-Tun Ho Hokai Hong-Lee_Hong-Li Hong 
+			Hongji Hougu How Hu-Hai Huan Hung Hyo_Hyo Hyuga 
+			Hyun 
 			Hai Han Hanbo Handa Handan Hanfeng Hangong
 			Hanhe Hannan Hanru Hansheng Hanwen Hanyu
 			Hanzong Hao He Hei Heng Ho Hong Hongda
@@ -139,6 +109,10 @@ earth_kingdom_culture = {
 			Huaiguang Huaishen Huaiyuan Huaizhen Huan
 			Huang Huangshang Hui Huiyang Hulin Hun
 			Hung Huo Huojin
+			Ieharu Iemune
+			Jae Jai-Ree Jai Jebe Jet Ji-Jia Ji Jia Jian Jiao-Long Jie Jin-Wei Jin 
+			Jing Jingbo Jochi Ju-Long Ju-Min Ju-Wei Ju-si Ju 
+			Jung Juno 
 			Ji Jia Jiafu Jian Jiang Jianguo Jianjun
 			Jiansu Jianyu Jianzhi Jiao Jiazhen Jie
 			Jiezi Jifu Jiguang Jin Jing Jingchen
@@ -148,26 +122,43 @@ earth_kingdom_culture = {
 			Jiuling Jizi Jong Ju Judao Jue Jugong Jun
 			Jung Junji Junjie Junliang Junshi Juyuan
 			Juzheng
-			Kai Kan Kang Ke Kong Kua Kuai Kuan Kuang
-			Kui Kuizi Kun
+			Kai Kaili Kang-Cong Kang Kanto Karu Kasuki_Kazuki Kei-See Kenji Ketuyu Keung Khal Ki Kim-Lee 
+			Kim Kokochu Kong Kopti Kosa_Koza Kosel_Kozel Kuei Kun 
+			Kuo-Yin Kuo Kon_Kuon Kwan 
+			Kan Kang Ke Kong Kua Kuai Kuan Kuang
+			Kui Kuizi
+			Lao Laquan Lee-Min Lee-Shen Lee-Wei Lee Lei Li Liang Lin-Yee Liu Long-Cheng 
+			Long-Dong Long-Fai Long-Fei Long-Feng Long-Shen Long Lu Lun-Quing 
 			Lai Lan Lang Lao Laohu Lei Li Lian Liang
 			Liangsi Liao Liben Lie Lin Linfu Ling
 			Linghu Liqing Lishi Liu Liwei Long Longji
 			Longlong Longwei Lou Lu Lue Lun Luo Luxi
+			Lun Luu-Kass
+			Macao Mako Malu Mang_Mangokpok Masaharu Masanobu 
+			Megujin Menggei Min-Ho Min-Ki Min Ming Moku Muneie 
+			Muneuji 
 			Ma Mai Man Mang Mao Maojiang Maozhen Mea
 			Mei Meng Mi Mian Miao Min Ming Minghua
 			Mingli Minsheng Minzhe Minzhong Mo Mu
-			Na Nan Ne Ni Ning Niu
+			Na Nayaga Nobumaza_Nobumasa Nobuyasu Nogai Noritame 
+			Nan Ne Ni Ning Niu
+			Odchigin Oh Ohev Okhotur Onku Otaku Oyaji 
 			On Ou Ouyang
-			Pan Pang Pei Peng Pengju Pi Ping Pou Pu
-			Qi Qian Qianfan Qiang Qianyao Qiao Qin
-			Qinke Qiong Qing Qingshan Qinming Qinwang
+			Pao Peng-Bo Peng-Lun Peng Ping-Bai Ping Poi Pong Pu-On-Tim 
+			Pan Pang Pei Pengju Pi Pou Pu
+			Qi-Fu Qi Qian Qin Qing Quon 
+			Qianfan Qiang Qianyao Qiao
+			Qinke Qiong Qingshan Qinming Qinwang
 			Qiqiang Qiu Qixiang Qu Quan Qub Que Qun
-			Quon
+			Raiko Ratnapala Rian Ro-Bi Roi Ru Ruan-Jiang Ruan Ryan Ryu 
 			Ran Rang Rangneng Rangyi Rei Ren Renben
 			Rengui Renjie Renshi Renshu Renyuan
 			Riyong Rizhi Rong Rou Ru Ruan Ruhui Rui
 			Ruo
+			Saikhan San Sang-Kyu Sang-Min Saru Satoru Sensu Sha-Wan She-Fu She-Tao She Shen-Fu Shen-Long Shen-Ping Shen-Qi 
+			Shen-Ru Shen Sheng-She Sheng Shilugu_Zhilugu Shin Shinji Shiro Shu Si 
+			Sokal Songyuan_Zhongyuan Songzen_Songzan Sotan Stei-Fen Su Sud Sung 
+			Suogu Suyiketu Swami 
 			Sansi Sengru Shaiming Shan Shang Shanyuan
 			Shao Shaojing She Shen Sheng Shengcheng
 			Shenji Shenquan Shenxi Shenyou Shi Shidai
@@ -178,15 +169,23 @@ earth_kingdom_culture = {
 			Shunyuan Shuo Si Sifu Sihui Sili Sima
 			Siqian Sitong Siyu Song Songzhi Su Sui
 			Suiliang Sun Suo
+			Tahn Tamenori Tao-Long Tao-Xia Tao Temujin Temur Teo Tian-Wei Tian Tiande Todogen Tolui 
+			Tong Toza Tsuneaki Tu Tugor Tumen Tycho Tyro 
 			Ta Tai Taishi Tan Tang Tao Taotu Taoyu Te
 			Teng Tengfei Ti Tian Tiankai Tianxi Tiao
 			Tie Ting Tingzhe Tong Tu Tung Tuo Tuoren
+			Uge Uji_Ujimune Ukhuna Usluk_Uzluk Usur_Uzur 
+			Vijaya 
+			Wan Wang-Long Wang Wei-Jin Wei-Li Wei Wen Wenshunu Wing Wolila 
+			Wu Wuge Wuyu 
 			Wai Wan Wang Wangzhuo Wannian Wansui Wei
 			Weidao Weihao Weihuang Weimin Weiping
 			Weiqian Weisheng Weiyuan Weizhi Wen
 			Wenben Wenchang Wencheng Wenguan Wenjie
 			Wenjing Wenshu Wenwei Wenyan Wing Wo Wu
 			Wuji Wukong Wuzhen Wuzhong Wuzhou Wuzi
+			Xai-Bau Xai Xian-Lee Xian Xie-Chao 
+			Xie-Tao Xie Xin-Fu Xin Xing Xingke Xiuge Xun 
 			Xi Xia Xiahou Xian Xiande Xiang Xiangdao
 			Xiangruo Xiangxian Xianke Xiao Xiaochang
 			Xiaode Xiaojian Xiaojie Xiaoping
@@ -196,6 +195,10 @@ earth_kingdom_culture = {
 			Xiujing Xu Xuan Xuande Xuangui Xuanling
 			Xuantong Xuanwei Xuanyang Xuanzong Xue
 			Xueqin Xueyou Xun Xunyu Xunzi
+			Yanchege Yang-Yu Yang Yanxi Yashi Yasunobu Yedi Yegu 
+			Yeke Yi-Ming Yi-Tian Yi Yie-Bei Yilie Yin-Lee Yin-Long 
+			Yin Ying-Yu Ying Yoh Yong-Fang Yong-Min Yong Young 
+			Yu-Yu Yu Yuan Yun-Lee Yun Yung Yuu
 			Yan Yanbo Yanchang Yanfan Yang Yanjing
 			Yanlin Yanruo Yanshang Yanshou Yanwei
 			Yanzhao Yanzuo Yao Yaochuan Yaoqin
@@ -209,6 +212,7 @@ earth_kingdom_culture = {
 			Yuanyuan Yuanzhen Yuanzhong Yuanzong Yue
 			Yun Yunchang Yunlu Yunxu Yunyuan Yuqing
 			Yusheng Yushi
+			Zaheer Zei
 			Zai Zaisi Zan Zang Zao Ze Zedong Zeng
 			Zengguang Zenguang Zha Zhai Zhan Zhang
 			Zhangke Zhao Zhaode Zhaodu Zhaoxun Zhen
@@ -226,137 +230,128 @@ earth_kingdom_culture = {
 			Zongru Zou Zu Zuan Zun Zunqing Zuo
 		}
 		female_names = {
-			Adi_Adi Ae_Ae Aeko_Aeko Ageha_Ageha Ah-Ho_Ah-Ho Ah_Ah Ahnah_Ahnah Ai-Laomay_Ai-Laomay 
-			Ai_Ai Akira_Akira Alan_Alan Am-Lee-Ah_Am-Lee-Ah An-Ah_An-Ah An-Lee_An-Lee An-ji_An-ji An_An 
-			Asami_Asami Ash-Lee_Ash-Lee Asusako_Asusako Aya_Aya Bage_Bage Bao-Lee_Bao-Lee Bao_Bao Biming_Biming 
-			Blossom_Blossom Boshi_Boshi Botokhui_Botokhui Bunko_Bunko Buttercup_Buttercup Chabi_Chabi Chang_Chang Changshou_Changshou 
-			Chaogui_Chaogui Chen-Ah_Chen-Ah Chen-Chun_Chen-Chun Chen-Lee_Chen-Lee Chen_Chen Chi-Chi_Chi-Chi Chi-Tai_Chi-Tai Chi_Chi 
-			Chin_Chin Ching-Lan_Ching-Lan Chise_Chise Chong-Lee_Chong-Lee Chotan_Chotan Chu-hua_Chu-hua Chun-Hei_Chun-Hei Chun-Lee_Chun-Lee 
-			Chun-Pu_Chun-Pu Chun_Chun Clover_Clover Cong-Ho_Cong-Ho Cong_Cong Cuiba_Cuiba Dahlia_Dahlia Daisy_Daisy 
-			Dao-Han_Dao-Han Dao-Lee_Dao-Lee Dao-ming_Dao-ming Dawei_Dawei Dianni_Dianni Eh-Rin_Eh-Rin Ei-Dee_Ei-Dee Em-Lee_Em-Lee 
-			Eun-Mi_Eun-Mi Eun-Sun_Eun-Sun Eun_Eun Fa-Fen_Fa-Fen Fa-Lee_Fa-Lee Fa-Lin_Fa-Lin Fa-Song_Fa-Song Fa_Fa 
-			Fan-Fan_Fan-Fan Fan-Fen_Fan-Fen Fan-He_Fan-He Fan_Fan Fang_Fang Feiyan_Feiyan Fen-Fen_Fen-Fen Fen-Violet_Fen-Violet 
-			Fen_Fen Feng-Shu_Feng-Shu Fu-Chi_Fu-Chi Fu-Ji_Fu-Ji Fu_Fu Fuku_Fuku Fumi_Fumi Fuse_Fuse 
-			Fuuko_Fuuko Fuutaba_Fuutaba Hail-Lee_Hail-Lee Han-Wei_Han-Wei Han_Han Hana_Hana Hang-Lee_Hang-Lee Hang_Hang 
-			Haruka_Haruka He-Qi_He-Qi Hei-Won_Hei-Won Hide_Hide Hisumei_Hisumei Ho-Lee_Ho-Lee Ho-Ya_Ho-Ya Ho_Ho 
-			Hong_Hong Hope_Hope Hou-Ting_Hou-Ting Hou-Yan_Hou-Yan Hou_Hou Ichiko_Ichiko Im-Lee_Im-Lee Ipek_Ipek 
-			Iris_Iris Ivy_Ivy Jae_Jae Jasmine_Jasmine Ji_Ji Jia_Jia Jiangnu_Jiangnu Jin_Jin 
-			Jira_Jira Jiuge_Jiuge Jojo_Jojo Joo-Dee_Joo-Dee Ju-Lee_Ju-Lee Ju_Ju Jun-Pu_Jun-Pu Jun_Jun 
-			June_June Kai-Lee_Kai-Lee Kait-Lin_Kait-Lin Kaya_Kaya Ke-Lee_Ke-Lee Kei_Kei Keiri_Keiri Khogaghchin_Khogaghchin 
-			Khulan_Khulan Kikyo_Kikyo Kim-Lee_Kim-Lee Kim_Kim Kirei_Kirei Koko_Koko Konata_Konata Kori_Kori 
-			Koto_Koto Kotobuki_Kotobuki Kuvira_Kuvira Kyoshi_Kyoshi Lan-Xin_Lan-Xin Lan_Lan Le-Ah_Le-Ah Lee-An_Lee-An 
-			Lee-Han_Lee-Han Lee-Lee_Lee-Lee Lee-Pu_Lee-Pu Lee-Wei_Lee-Wei Lee-Yan_Lee-Yan Lee-hou_Lee-hou Lee_Lee Lei-An_Lei-An 
-			Lei_Lei Li_Li Lian_Lian Liang_Liang Lien_Lien Lihua_Lihua Lilac_Lilac Liling_Liling 
-			Lily-Ling_Lily-Ling Lily_Lily Lin-Lin_Lin-Lin Lin_Lin Lina_Lina Ling-Ling_Ling-Ling Ling-Min_Ling-Min Ling-Wei_Ling-Wei 
-			Ling_Ling Liu-Liu_Liu-Liu Liu_Liu Lo_Lo Lokai_Lokai Lu-Chu_Lu-Chu Lubugu_Lubugu Macmu-Ling_Macmu-Ling 
-			Magnolia_Magnolia Mah_Mah Makh_Makh Marigold_Marigold Meel-Itza_Meel-Itza Megumi_Megumi Mei-Lee_Mei-Lee Mei-Xing_Mei-Xing 
-			Mei_Mei Meng-Meng_Meng-Meng Meng_Meng Mi-Ah_Mi-Ah Mi-Hi_Mi-Hi Mi-Sun_Mi-Sun Micha_Micha Mikasa_Mikasa 
-			Min-Jee_Min-Jee Min-Lee_Min-Lee Min_Min Misun_Misun Mitsu_Mitsu Miyabi_Miyabi Miyako_Miyako Mo-Lee_Mo-Lee 
-			Mo-Li_Mo-Li Mo-Song_Mo-Song Myung_Myung Na-Ai_Na-Ai Na-An_Na-An Na_Na Nana_Nana Nanai_Nanai 
-			Nanaidhat_Nanaidhat Naoki_Naoki Nat-Lee_Nat-Lee Navvaba_Navvaba Nazilla_Nasilla Nomolun_Nomolun Nosumi_Nozumi Nuan-Fen_Nuan-Fen 
-			Nuan_Nuan Ny_Ny Oma_Oma Opal_Opal Orchid_Orchid Pansy_Pansy Parvin_Parvin Pema_Pema 
-			Peng_Peng Penga_Penga Peony_Peony Po-Lee_Po-Lee Ponyo_Ponyo Poppy_Poppy Pu_Pu Pusuwan_Pusuwan 
-			Qi_Qi Rani_Rani Ranisa_Ranisa Riza_Riza Rizua_Rizua Rong_Rong Roxana_Roxana Ru_Ru 
-			Rui-Yun_Rui-Yun Rui_Rui Sai_Sai Saige_Saige Sakae_Sakae Sang-Hee_Sang-Hee Sari_Sari Sato_Sato 
-			Sei_Sei Sela_Sela Senna_Senna Seon_Seon Shan_Shan Shayn_Shayn Shengtong_Shengtong Shige_Shige 
-			Shiori_Shiori Shirin_Shirin Shu-Fang_Shu-Fang Shu_Shu Shulu-Ping_Shulu-Ping Shun_Shun Shuogu_Shuogu So-Young_So-Young 
-			Sokhatai_Sokhatai Song-An_Song-An Song-Fan_Song-Fan Song-Lee_Song-Lee Song_Song Soo-Jin_Soo-Jin Soo-Min_Soo-Min Soo-Yun_Soo-Yun 
-			Soon-Bok_Soon-Bok Star_Star Stei-See_Stei-See Su_Su Sue-Si_Shu-Zi Suki_Suki Sum-Ting-Rong_Sum-Ting-Rong Sun_Sun 
-			Suyin_Suyin Tabuyan_Tabuyan Tae_Tae Tai-Yue_Tai-Yue Tai_Tai Taige_Taige Taoge_Taoge Tati_Tati 
-			Ting_Ting Tomo_Tomo Tomoe_Tomoe Toph_Toph Touran_Touran Tsukasa_Tsukasa Tsuki_Tsuki Tu-Lee_Tu-Lee 
-			Tu-Ling_Tu-Ling Tu_Tu Tura_Tura Tuyen_Tuyen Ty-Lee_Ty-Lee Ula_Ula Umi_Umi Uta_Uta 
-			Vina_Vina Violet_Violet Watari_Watari Wei-Lee_Wei-Lee Wei_Wei Wen-Yen_Wen-Yen Won-Yee_Won-Yee Wu_Wu 
-			Xia_Xia Xiao-Wen_Xiao-Wen Xiao_Xiao Xin-Xin_Xin-Xin Xin_Xin Xing-Ying_Xing-Ying Xing_Xing Xingge_Xingge 
-			Xingke_Xingke Xue_Xue Ya-Rong_Ya-Rong Ya-Wei_Ya-Wei Ya_Ya Yan_Yan Yange_Yange Yanmu_Yanmu 
-			Yasaman_Yasaman Yasar_Yasar Yasuko_Yasuko Yee-Li_Yee-Li Yen_Yen Yena_Yena Yesugun_Yesugun Yin_Yin 
-			Ying_Ying Yingtian_Yingtian Yoiko_Yoiko Yong_Yong Yoshi_Yoshi Young-Mi_Young-Mi Yue-Han_Yue-Han Yue-Lee_Yue-Lee 
-			Yue-Yun_Yue-Yun Yue_Yue Yume_Yume Yun_Yun Yuu_Yuu Zamara_Zamara Zo-He_Zo-He
-			Ai Aili Ailing Aimei Aiqin Aman An Anyang
-			Anzong Awu
-			Bai Bao Baoming Baosi Baoyu Baozhai Baozhu Bing
-			Bingyi Biniang Biyu Bo
-			Cai Caichun Caihua Caiping Cha Chang Changchang
-			Changyi Changying Chaochao Chen Chenguang Chi
+			Adi Ae Aeko Ageha Ah-Ho Ah Ahnah Ai-Laomay 
+			Ai Aili Ailing Aimei Aiqin Akira Alan Am-Lee-Ah Aman An Anyang
+			An-Ah An-Lee An-ji Anzong
+			Asami Ash-Lee Asusako Awu Aya
+			Bage Bai Bao Baoming Baosi Baoyu Baozhai Baozhu Bao-Lee Bao Biming 
+			Bing Bingyi Biniang Biyu Bo
+			Blossom Boshi Botokhui Bunko Buttercup 
+			Cai Caichun Caihua Caiping
+			Cha Chabi Chang Changyi Changying Changshou Changchang Chaochao
+			Chaogui Chen Chen-Ah Chen-Chun Chenguang Chen-Lee Chen Chi-Chi Chi-Tai Chi 
+			Chin Ching-Lan Chise Chong-Lee Chotan Chu-hua Chun-Hei Chun-Lee 
 			Chiying Chongyan Chuanzhu Chuhua Chunhua Chunluo
 			Chuntao Chunyan Cuiqiao
-			Daiyu Damei Dandan Daoan Daofei Daoqing Daoyi
-			Daozheng Daqiao Daya Dayi Dehua Dexiu Diaochan
-			Dongmei
-			E Ehuang Erzhu Ezi
-			Fa Fahui Fan Fang Fangmei Fani Fanjing Farong
+			Chun-Pu Chun Clover Cong-Ho Cong Cuiba 
+			Dahlia Daisy Daiyu Dianni     
+			Dao-Han Dao-Lee Dao-ming Damei Dandan Daoan Daofei Dawei Daoqing Daoyi Daozheng Daqiao Daya Dayi 
+			Dehua Dexiu Diaochan Dongmei
+			E Eh-Rin Ehuang Ei-Dee Em-Lee Erzhu
+			Eun-Mi Eun-Sun Eun Ezi
+			Fa Fa-Fen Fahui Fa-Lee Fan Fang Fangmei Fani Fanjing Fa-Lin Fa-Song 
+			Fan-Fan Fan-Fen Fan-He Fan Fang Farong Feiyan Fen-Fen Fen-Violet 
+			Fen Feng-Shu Fu-Chi Fu-Ji Fu Fuku Fumi Fuse 
+			Fuuko Fuutaba 						
 			Feishan Feiyan Fenfang Feng Fengniang Fu Fujin
 			Fuyuan
 			Gaowei Gaozong Guang Guangji Gui Guifei Guilan
 			Guinu Guiying Guo Guoer
-			Hai Han Hang Hanyue He Helian Hengbo Hong
-			Honghong Honghua Hongyu Hou Hua Huali Hualing
-			Huan Huanghua Huawan Huazhuang Huer Hui Huian
+			Hai Hail-Lee Han-Wei Han Hana Hang-Lee Hang Hanyue
+			Haruka He Helian Hengbo He-Qi Hei-Won Hide Hisumei Ho-Lee Ho-Ya Ho Hong Honghong Honghua Hongyu 
+			Hope Hou Hou-Ting Hou-Yan Hou Hua Huali Hualing Huan Huanghua Huawan Huazhuang 
+			Huer Hui Huian
 			Huidai Huiduan Huifei Huilan Huimei Huimin
 			Huinan Huiqing Huitong Huizhao Huizhong Huiyu
-			Ji Jia Jian Jiang Jiangnu Jiangqing Jiangui
-			Jianrong Jianwen Jiao Jiayi Jiaying Jicong Jie
-			Jieyou Jieyu Jijiang Jiner Jinfeng Jing Jingai
+			Ichiko Im-Lee Ipek 
+			Iris Ivy 
+			Jae Jasmine Ji Jia Jian Jiang Jiangnu Jiangqing Jiangui Jianrong 
+			Jianwen Jiao Jiayi Jiaying Jicong Jie Jieyou Jieyu Jijiang
+			Jin Jiner Jinfeng Jing Jingai
 			Jinghua Jinghuai Jinghui Jingshou Jingyan
 			Jingying Jingyue Jinhu Jinhua Jinluan Jinluo
-			Jinnu Jinxian Jinzhu Jiuchang Jun
-			Kaidi Kangyi Ki Ko Kou
-			Lan Lanbi Lanying Li Lian Lianshi Lien Lieying
-			Lihua Lijuan Liling Lin Linfen Linfeng Ling
-			Lingbing Lingfeng Lingguang Lingji Lingnu Lingqi
-			Lingqu Lingxuan Lingyang Lingying Lingyuan
-			Lingyue Liqiu Liu Lize Lizhi Luban Luyin Luyu
-			Luzhen
-			Mai Mantang Manyue Maoer Maoying Maozhen Mei
-			Meifeng Meihua Meihui Meilin Meiling Meirong
-			Meiting Meixing Meixiu Meiying Meizi Min Ming
-			Mingda Minghua Mingxia Mingxiang Mingyu Mingyue
-			Mulan Muzhi
-			Na Najie Nanfeng Nanxian Naying Nenniang Niangzi
-			Ning Ninghong Nizi Nuo Nuwa Nuwang
-			Panpan Peizhi Ping Pinghua Pingling Piyang Puxian
-			Qiang Qianfei Qiao Qiaolian Qiaoyun Qichang Qieluo
+			Jinnu Jinxian Jinzhu Jiuchang
+			Jira Jiuge Jojo Joo-Dee Ju-Lee Ju Jun-Pu Jun 
+			June 					
+			Kai-Lee	Kaidi    
+ 			Kait-Lin Kangyi Kaya Ke-Lee Kei Keiri Khogaghchin 
+			Khulan Ki Kikyo Kim-Lee Kim Kirei Ko Koko Konata Kori 
+			Koto Kotobuki Kou Kuvira Kyoshi 
+			Lan Lanbi Lan-Xin Lanying Le-Ah Lee-An_Lei-An 
+			Lee-Han Lee-Lee Lee-Pu Lee-Wei Lee-Yan Lee-hou Lee Lei-An 
+			Lei Li Lian Liang Lianshi Lien Lieying Lihua Lijuan    
+			Lilac Liling Lily-Ling Lily Lin-Lin Lin Lina Linfen Linfeng Ling Ling-Ling Lingbing Lingfeng Lingguang Lingji 
+			Ling-Min Lingnu Lingqi Lingqu Ling-Wei Lingxuan Lingyang Lingying Lingyuan Lingyue
+			Ling Liqiu Liu-Liu Liu Lize Lizhi
+			Lo Lokai 
+			Lu-Chu Luban Lubugu Luyin Luyu Luzhen
+			Macmu-Ling Magnolia Mah Mai Makh Mantang Manyue Marigold Maoer Maoying Maozhen 
+			Meel-Itza Megumi Mei-Lee Mei-Xing     			
+			Mei Meng-Meng Meng Meifeng Meihua Meihui Meilin Meiling Meirong
+			Meiting Meixing Meixiu Meiying Meizi Mi-Ah Mi-Hi Mi-Sun Micha Mikasa 
+			Min-Jee Min-Lee Min Ming Mingda Minghua Mingxia Mingxiang Mingyu Mingyue 
+			Misun Mitsu Miyabi Miyako Mo-Lee 
+			Mo-Li Mo-Song 
+			Mulan Muzhi Myung 
+			Na-Ai Na-An Na Najie Nana Nanai Nanfeng 
+			Nanaidhat Nanxian Naoki Nat-Lee Navvaba Naying Nazilla Nenniang
+			Niangzi Ning Ninghong Nizi Nomolun Nosumi Nuan-Fen 
+			Nuan Nuo Nuwa Nuwang Ny 
+			Oma Opal Orchid 			
+			Panpan Pansy Parvin Pema Peizhi
+			Peng Penga Peony Ping Pinghua Pingling Piyang Po-Lee Ponyo Poppy Pu Pusuwan Puxian
+			Qi Qiang Qianfei Qiao Qiaolian Qiaoyun Qichang Qieluo
 			Qigui Qing Qinger Qinghe Qingling Qingyu Qingzhao
 			Qiniang Qiu Qiuniang Que Quyi
-			Rong Ronghua Rongji Rou Rouniang Rounu Rui Ruirong
+			Rani Ranisa Riza Rizua Rong Ronghua Rongji Rou Rouniang Rounu  
+			Roxana Ru Rui-Yun Rui Ruirong
 			Ruogan Ruolan Ruomei Ruoxian Ruoxin Ruoxun Ruozhao
 			Rushi Ruying
-			Saihua Sanjing Sanniang Shan Shangrou Shangxiang
-			Shanli Shanshan Shanwei Shanxiang Shaoji Shaoming
-			Shenai Shengqiong Shengtong Shi  Shier Shiguang
-			Shinan Shou Shouji Shouying Shu Shuang Shun
-			Shunhua Shunxuan Shuozhen Shuyi Shuyuan Shuzhen
-			Shuzhu Siniang Song Su Suanzi Sujie Suyue Suyin
-			Suying Suzhen
-			Tai Taihua Taisi Taiying Taizhen Tao Taotao Ting
+			Sai Saihua Saige Sang-Hee Sakae Sanjing Sanniang Sari Sato 
+			Sei Sela Senna Seon Shan Shayn Shengtong Shige 
+			Shan Shangrou Shangxiang Shanli Shanshan Shanwei Shanxiang Shaoji Shaoming
+			Shenai Shengqiong Shengtong Shi Shier Shiori Shirin Shiguang Shu-Fang Shinan Shou Shouji Shouying Shu Shuang 
+			Shulu-Ping Shun Shunhua Shunxuan Shuogu Shuozhen Shuyi Shuyuan Shuzhen Shuzhu Siniang So-Young 
+			Sokhatai Song Song-An Song-Fan Song-Lee Song Soo-Jin Soo-Min Soo-Yun 
+			Soon-Bok Star Stei-See Su Sue-Si_Shu-Zi Suki Sum-Ting-Rong Su Suanzi Sun 
+			Sujie Suyue Suyin Suying Suzhen
 			Tiying Tonge Tu
-			Waner Wangmu Wanyi Wanying Weici Weiwen Wen
-			Wencheng Wenji Wenjun Wenqian Wenshou Wenxiu
-			Wenzhao Wuhua Wuxian Wuyin
-			Xanghua Xian Xiane Xiang Xiangjun Xianglan
-			Xiangyun Xianhui Xianji Xianrong Xianying
+			Tabuyan Tae Tai-Yue Tai Taihua Taige Taisi Taiying Taoge Tati 
+			Taizhen Tao Taotao Ting Tomo Tomoe Toph Touran Tsukasa Tsuki Tu-Lee 
+			Tu-Ling Tu Tura Tuyen Ty-Lee 
+			Ula Umi Uta 
+			Vina Violet 
+			Watari Waner Wangmu Wanyi Wanying
+			Wei-Lee Wei Weici Weiwen 
+			Wen Wen-Yen Wencheng Wenji Wenjun Wenqian Wenshou Wenxiu
+			Wenzhao 
+			Won-Yee Wu Wuhua Wuxian Wuyin
+			Xanghua Xia Xian Xiane 
+			Xiang Xiangyun Xianhui Xianji Xianrong Xianying
 			Xianyuan Xianzi Xiao Xiaocha Xiaodong Xiaodan
-			Xiaoe Xiaofan Xiaohua Xiaohui Xiaoji Xiaojin
-			Xiaojing Xiaoli Xiaolian Xiaoling Xiaomai Xiaomei
-			Xiaomin Xiaosheng Xiaotong Xiaowan Xiaowen
+			Xiaofan Xiaohua Xiaohui Xiaoji Xiaojin Xiaojing Xiangjun Xianglan 
+			Xiao-Wen Xiao Xiaoe Xiaoli Xiaolian Xiaoling Xiaomai Xiaomei Xiaomin Xiaosheng Xiaotong Xiaowan Xiaowen
 			Xiaoya Xiaoyanzi Xiaoying Xiaoyuan Xiaozhao
-			Xiaozhi Xier Xijie Xijun Xingcai Xinghua
-			Xingmei Xingnu Xinyue Xiu Xiulan Xiurong
-			Xiuui Xiuying Xiuyong Xuanzong Xuchen Xue
-			Yan Yanlin Yanxiang Yanyan Yanyu Yanzi Yaoer
-			Yen Yenai Yi Yian Yijiang Yifu Ying Yinge
-			Yingmei Yingtai Yingwu Yinping Yixing Yiyang
-			Youwei Youwu Yu Yuan Yuanhua Yuanji Yuantong
-			Yuanyuan Yue Yuer Yueshang Yueyi Yueying
-			Yuguang Yuhua Yuhuan Yujing Yujiulu Yuming
-			Yuniang Yunru Yunu Yunxian Yupan Yuwen Yuyi
-			Yuying Yuzhu
-			Zetian Zhangde Zhangsun Zhaohui Zhaojun Zhaopei
+			Xiaozhi 
+			Xier Xijie Xijun
+			Xin-Xin Xin Xing-Ying Xing Xingcai Xingge Xinghua
+			Xingke Xingmei Xingnu Xinyue Xiu Xiulan Xiurong
+			Xiuui Xiuying Xiuyong Xuanzong Xuchen Xue 
+			Ya-Rong Ya-Wei Ya Yan Yange Yanlin Yanmu Yanxiang Yanyan Yanyu Yanzi
+			Yaoer Yasaman Yasar Yasuko Yee-Li Yen Yena Yenai Yesugun Yi Yian Yijiang Yifu
+			Yin Ying Yinge Yingmei Yingtai Yingtian Yingwu Yinping Yixing Yiyang 
+			Yoiko Yong Yoshi Young-Mi Youwei Youwu Yu Yuan Yuanhua Yuanji Yuantong
+			Yuanyuan Yue-Han Yue-Lee 
+			Yue-Yun Yue Yuer Yueshang Yueyi Yueying Yuguang Yuhua Yuhuan Yujing Yujiulu Yume Yuming
+			Yun Yuniang Yunru Yunu Yunxian Yupan Yuu Yuwen Yuyi
+			Yuying Yuzhu    
+			Zamara Zo-He Zetian Zhangde Zhangsun Zhaohui Zhaojun Zhaopei
 			Zhaorong Zhaoyi  Zhaoyun Zhen Zhener Zhenfeng
 			Zheng Zhenji Zhenli Zhenniang Zhenyi Zhenzhen
 			Zhenzong Zhi Zhichong Zhide Zhihui Zhilan
 			Zhirong Zhonghua Zhongmei Zhongyang Zhou Zhu
 			Zhuozhen Zhurong Zhuzhu Zi Ziwei Zongying Zue
-			Zuimei Zuqi
+			Zuimei Zuqi	  
 	   }
 	   
 		dukes_called_kings = no
@@ -393,96 +388,124 @@ earth_kingdom_culture = {
 		color = { 6 138 0 }
 		
 		male_names = {
-			Abaoji_Abaoji Aiwei_Aiwei Akisada_Akisada Akitaka_Akitaka Akitsune_Akitsune Alp_Alp Anxi_Anxi Ao-Bang_Ao-Bang 
-			Ao_Ao Aoda_Aoda Arik_Arik Baatar_Baatar Bai-Kong_Bai-Kong Bai_Bai Bang_Bang Baras_Baraz 
-			Bei_Bei Biegute_Biegute Bishe_Bishe Blush_Blush Bo-Bee_Bo-Bee Bo-Bi_Bo-Bi Bo-Bo_Bo-Bo Bo-Lee_Bo-Lee 
-			Bo-Rei_Bo-Rei Bo_Bo Bohai_Bohai Bolin_Bolin Brei-Dee_Brei-Dee Bumi_Bumi Bushi_Bushi Butakha_Butakha 
-			Buwei_Buwei Cao-Cao_Cao-Cao Cao-Dee_Cao-Dee Cao_Cao Chanai_Chanai Changdong_Changdong Chao_Chao Cheng_Cheng 
-			Chin_Chin Chit-Sang_Chit-Sang Chong_Chong Chow_Chow Chung_Chung Cong_Cong Da_Da Dai-Lee_Dai-Lee 
-			Dai_Dai Daquan_Daquan Dashi_Dashi Daw_Daw Deguang_Deguang Deming_Deming Dilie_Dilie Dong-Long_Dong-Long 
-			Dong-Min_Dong-Min Dong_Dong Du-Ho_Du-Ho Duolubu_Duolubu Eh-Dee_Eh-Dee Fai_Fai Fang_Fang Fei_Fei 
-			Feng-Long_Feng-Long Feng_Feng Fong_Fong Fu_Fu Fugazhi_Fugazhi Fuguzhi_Fuguzhi Fuling-Ji_Fuling-Ji Fuling_Fuling 
-			Fung_Fung Gai-Ree_Gai-Ree Ganbat_Ganbat Gang_Gang Gansu_Gansu Gao_Gao Gaye_Gaye Ghazan_Ghazan 
-			Godan_Godan Gommu_Gommu Gopala_Gopala Gorota_Gorota Gou'er_Gou'er Gow_Gow Gsi_Gzi Guang_Guang 
-			Gun_Gun Guo_Guo Hai_Hai Harghasun_Harghasun Harjjaravarman_Harjjaravarman Haru_Haru Haruie_Haruie Harumasa_Harumasa 
-			He_He Heng_Heng Hiroshi_Hiroshi Ho-Tun_Ho-Tun Ho_Ho Hokai_Hokai Hong-Lee_Hong-Li Hong_Hong 
-			Hongji_Hongji Hougu_Hougu How_How Hu-Hai_Hu-Hai Huan_Huan Hung_Hung Hyo_Hyo Hyuga_Hyuga 
-			Hyun_Hyun Ieharu_Ieharu Iem_Iemune Ikem_Ikem Jae_Jae Jai-Ree_Jai-Ree Jai_Jai Jebe_Jebe 
-			Jet_Jet Ji-Jia_Ji-Jia Ji_Ji Jia_Jia Jian_Jian Jiao-Long_Jiao-Long Jie_Jie Jin-Wei_Jin-Wei 
-			Jin_Jin Jing_Jing Jingbo_Jingbo Jochi_Jochi Ju-Long_Ju-Long Ju-Min_Ju-Min Ju-Wei_Ju-Wei Ju-si_Ju-si 
-			Ju_Ju Jung_Jung Juno_Juno Kai_Kai Kaili_Kaili Kang-Cong_Kang-Cong Kang_Kang Kanto_Kanto 
-			Karu_Karu Kasuki_Kazuki Kei-See_Kei-See Kenji_Kenji Ketuyu_Ketuyu Keung_Keung Khal_Khal Ki_Ki 
-			Kim-Lee_Kim-Lee Kim_Kim Kokochan_Kokochu Kong_Kong Kopti_Kopti Kosa_Koza Kosel_Kozel Kuei_Kuei 
-			Kun_Kun Kuo-Yin_Kuo-Yin Kuo_Kuo Kuon_Kuon Kwan_Kwan Lao_Lao Laquan_Laquan Lee-Min_Lee-Min 
-			Lee-Shen_Lee-Shen Lee-Wei_Lee-Wei Lee_Lee Lei_Lei Li_Li Liang_Liang Lin-Yee_Lin-Yee Liu_Liu 
-			Long-Cheng_Long-Cheng Long-Fai_Long-Fai Long-Fei_Long-Fei Long-Feng_Long-Feng Long-Shen_Long-Shen Long-Wang_Long-Wang Long_Long Lu_Lu 
-			Lun-Quing_Lun-Quing Lun_Lun Luu-Kass_Luu-Kass Macao_Macao Mako_Mako Malu_Malu Mang_Mangokpok Masaharu_Masaharu 
-			Masanobu_Masanobu Megujin_Megujin Menggei_Menggei Min-Ho_Min-Ho Min-Ki_Min-Ki Min_Min Ming_Ming Moku_Moku 
-			Muneie_Muneie Muneuji_Muneuji Na_Na Nayaga_Nayaga Nobasu_Nobuyasu Nobumasa_Nobumasa Nogai_Nogai Noritame_Noritame 
-			Odchigin_Odchigin Oh_Oh Ohev_Ohev Okhotur_Okhotur Onku_Onku Otaku_Otaku Oyaji_Oyaji Pao_Pao 
-			Peng-Bo_Peng-Bo Peng-Lun_Peng-Lun Peng_Peng Ping-Bai_Ping-Bai Ping_Ping Poi_Poi Pong_Pong Pu-On-Tim_Pu-On-Tim 
-			Qi-Fu_Qi-Fu Qi_Qi Qian_Qian Qin_Qin Qing_Qing Quon_Quon Raiko_Raiko Ratnapala_Ratnapala 
-			Rian_Rian Ro-Bi_Ro-Bi Roi_Roi Ru_Ru Ruan-Jiang_Ruan-Jiang Ruan_Ruan Ryan_Ryan Ryu_Ryu 
-			Saikhan_Saikhan San_San Sang-Kyu_Sang-Kyu Sang-Min_Sang-Min Saru_Saru Satoru_Satoru Sensu_Sensu Sha-Wan_Sha-Wan 
-			She-Fu_She-Fu She-Tao_She-Tao She_She Shen-Fu_Shen-Fu Shen-Long_Shen-Long Shen-Ping_Shen-Ping Shen-Qi_Shen-Qi Shen-Ru_Shen-Ru 
-			Shen_Shen Sheng-She_Sheng-She Sheng_Sheng Shilugu_Zhilugu Shin_Shin Shinji_Shinji Shiro_Shiro Shongyuan_Zhongyuan 
-			Shu_Shu Si_Si Sokal_Sokal Songzen_Songzan Sotan_Sotan Stei-Fen_Stei-Fen Su_Su Sud_Sud 
-			Sung_Sung Suogu_Suogu Suyiketu_Suyiketu Swami_Swami Tahn_Tahn Taku_Taku Tamenori_Tamenori Tao-Long_Tao-Long 
-			Tao-Xia_Tao-Xia Tao_Tao Temujin_Temujin Temur_Temur Teo_Teo Tian-Wei_Tian-Wei Tian_Tian Tiande_Tiande 
-			Todogen_Todogen Tolui_Tolui Tom-Tom_Tom-Tom Tong_Tong Toza_Toza Tsunaki_Tsuneaki Tu_Tu Tugor_Tugor 
-			Tumen_Tumen Tycho_Tycho Tyro_Tyro Uge_Uge Ujimune_Ujimune Ukhuna_Ukhuna Usluk_Uzluk Vijaya_Vijaya 
-			Wan_Wan Wang-Long_Wang-Long Wang_Wang Wei-Jin_Wei-Jin Wei-Li_Wei-Li Wei_Wei Wen_Wen Wenshunu_Wenshunu 
-			Wing_Wing Wolila_Wolila Wu_Wu Wuge_Wuge Wuyu_Wuyu Xai-Bau_Xai-Bau Xai_Xai Xian-Lee_Xian-Lee 
-			Xian_Xian Xie-Chao_Xie-Chao Xie-Tao_Xie-Tao Xie_Xie Xin-Fu_Xin-Fu Xin_Xin Xing_Xing Xingke_Xingke 
-			Xiuge_Xiuge Xun_Xun Yanchege_Yanchege Yang-Yu_Yang-Yu Yang_Yang Yanxi_Yanxi Yashi_Yashi Yasunobu_Yasunobu 
-			Yedi_Yedi Yegu_Yegu Yeke_Yeke Yi-Ming_Yi-Ming Yi-Tian_Yi-Tian Yi_Yi Yie-Bei_Yie-Bei Yilie_Yilie 
-			Yin-Lee_Yin-Lee Yin-Long_Yin-Long Yin_Yin Ying-Yu_Ying-Yu Ying_Ying Yoh_Yoh Yong-Fang_Yong-Fang Yong-Min_Yong-Min 
-			Yong_Yong Young_Young Yu_Yu Yuan_Yuan Yun-Lee_Yun-Lee Yun_Yun Yung_Yung Yuu_Yuu 
-			Zaheer_Zaheer Zei_Zei
+			Abaoji Aiwei Akisada Akitaka Akitsune Alp Anxi Ao-Bang 
+			Ao Aoda Arik 
+			Baatar Bai-Kong Bai Bang Baras_Baraz 
+			Bei Biegute Bishe Blush Bo-Bee Bo-Bi Bo-Bo Bo-Lee 
+			Bo-Rei Bo Bohai Bolin Brei-Dee Bumi Bushi Butakha 
+			Buwei
+			Cao-Cao Cao-Dee Cao Chanai Changdong Chao Cheng 
+			Chin Chit-Sang Chong Chow Chung Cong 
+			Da Dai-Lee Dai Daquan Dashi Daw Deguang Deming Dilie Dong-Long 
+			Dong-Min Dong Du-Ho Duolubu 
+			Eh-Dee 
+			Fai Fang Fei 
+			Feng-Long Feng Fong Fu Fugazhi Fuguzhi Fuling-Ji Fuling 
+			Fung 
+			Gai-Ree Ganbat Gang Gansu Gao Gaye Ghazan 
+			Godan Gommu Gopala Gorota Gou'er Gow Gsi_Gzi Guang
+			Gun Guo 
+			Hai Harghasun Harjjaravarman Haru Haruie Harumasa
+			He Heng Hiroshi Ho-Tun Ho Hokai Hong-Lee_Hong-Li Hong 
+			Hongji Hougu How Hu-Hai Huan Hung Hyo Hyuga 
+			Hyun 
+			Ieharu Iem_Iemune Ikem 
+			Jae Jai-Ree Jai Jebe 
+			Jet Ji-Jia Ji Jia Jian Jiao-Long Jie Jin-Wei 
+			Jin Jing Jingbo Jochi Ju-Long Ju-Min Ju-Wei Ju-si 
+			Ju Jung Juno
+			Kai Kaili Kang-Cong Kang Kanto 
+			Karu Kasuki_Kazuki Kei-See Kenji Ketuyu Keung Khal Ki
+			Kim-Lee Kim Kokochan_Kokochu Kong Kopti Kosa_Koza Kosel_Kozel Kuei 
+			Kun Kuo-Yin Kuo Kuon Kwan 
+			Lao Laquan Lee-Min 
+			Lee-Shen Lee-Wei Lee Lei Li Liang Lin-Yee Liu 
+			Long-Cheng Long-Fai Long-Fei Long-Feng Long-Shen Long-Wang Long Lu
+			Lun-Quing Lun Luu-Kass 
+			Macao Mako Malu Mang_Mangokpok Masaharu 
+			Masanobu Megujin Menggei Min-Ho Min-Ki Min Ming Moku 
+			Muneie Muneuji 
+			Na Nayaga Nobasu_Nobuyasu Nobumasa Nogai Noritame 
+			Odchigin Oh Ohev Okhotur Onku Otaku Oyaji 
+			Pao Peng-Bo Peng-Lun Peng Ping-Bai Ping Poi Pong Pu-On-Tim 
+			Qi-Fu Qi Qian Qin Qing Quon Raiko Ratnapala 
+			Rian Ro-Bi Roi Ru Ruan-Jiang Ruan Ryan Ryu 
+			Saikhan San_San Sang-Kyu Sang-Min Saru Satoru Sensu Sha-Wan 
+			She-Fu She-Tao She Shen-Fu Shen-Long Shen-Ping Shen-Qi Shen-Ru 
+			Shen Sheng-She Sheng Shilugu_Zhilugu Shin Shinji Shiro Shongyuan_Zhongyuan 
+			Shu Si Sokal Songzen Sotan Stei-Fen Su Sud
+			Sung Suogu Suyiketu Swami 
+			Tahn Taku Tamenori Tao-Long 
+			Tao-Xia Tao Temujin Temur Teo Tian-Wei Tian Tiande 
+			Todogen Tolui Tom-Tom Tong Toza Tsunaki Tu Tugor 
+			Tumen Tycho Tyro Uge Ujimune Ukhuna Usluk_Uzluk 
+			Vijaya 
+			Wan Wang-Long Wang Wei-Jin Wei-Li Wei Wen Wenshunu 
+			Wing Wolila Wu Wuge Wuyu 
+			Xai-Bau Xai Xian-Lee Xian Xie-Chao Xie-Tao Xie Xin-Fu Xin Xing Xingke 
+			Xiuge Xun 
+			Yanchege Yang-Yu Yang Yanxi Yashi Yasunobu 
+			Yedi Yegu Yeke Yi-Ming Yi-Tian Yi Yie-Bei Yilie 
+			Yin-Lee Yin-Long Yin Ying-Yu Ying Yoh Yong-Fang Yong-Min 
+			Yong Young Yu Yuan Yun-Lee Yun Yung Yuu 
+			Zaheer Zei
 		}
 		female_names = {
-			Adi_Adi Aeko_Aeko Ageha_Ageha Ah-Ho_Ah-Ho Ah_Ah Ahnah_Ahnah Ai-Laomay_Ai-Laomay Ai_Ai 
-			Akira_Akira Alan_Alan Am-Lee-Ah_Am-Lee-Ah An-Ah_An-Ah An-Lee_An-Lee An-ji_An-ji An_An Ansu_Anzu 
-			Asami_Asami Ash-Lee_Ash-Lee Asusako_Asusako Aya_Aya Bage_Bage Bao-Lee_Bao-Lee Bao_Bao Biming_Biming 
-			Blossom_Blossom Boshi_Boshi Botokhui_Botokhui Bunko_Bunko Buttercup_Buttercup Chabi_Chabi Chang_Chang Changshou_Changshou 
-			Chaogui_Chaogui Chen-Ah_Chen-Ah Chen-Chun_Chen-Chun Chen-Lee_Chen-Lee Chen_Chen Chi-Chi_Chi-Chi Chi-Tai_Chi-Tai Chi_Chi 
-			Chin_Chin Ching-Lan_Ching-Lan Chise_Chise Chong-Lee_Chong-Lee Chotan_Chotan Chu-hua_Chu-hua Chun-Lee_Chun-Lee Chun-Pu_Chun-Pu 
-			Chun_Chun Clover_Clover Cong-Ho_Cong-Ho Cong_Cong Cuiba_Cuiba Dahlia_Dahlia Daisy_Daisy Dao-Han_Dao-Han 
-			Dao-Lee_Dao-Lee Dao-ming_Dao-ming Dawei_Dawei Dianni_Dianni Eh-Rin_Eh-Rin Ei-Dee_Ei-Dee Em-Lee_Em-Lee Fa-Fen_Fa-Fen 
-			Fa-Lee_Fa-Lee Fa-Lin_Fa-Lin Fa-Song_Fa-Song Fa_Fa Fan-Fan_Fan-Fan Fan-Fen_Fan-Fen Fan-He_Fan-He Fan_Fan 
-			Fang_Fang Feiyan_Feiyan Fen-Fen_Fen-Fen Fen-Violet_Fen-Violet Fen_Fen Feng-Shu_Feng-Shu Fu-Chi_Fu-Chi Fu-Ji_Fu-Ji 
-			Fu_Fu Fuku_Fuku Fumi_Fumi Fuse_Fuse Fuuko_Fuuko Fuutaba_Fuutaba Hail-Lee_Hail-Lee Han-Wei_Han-Wei 
-			Han_Han Hang-Lee_Hang-Lee Hang_Hang Haruka_Haruka He-Qi_He-Qi Hei-Won_Hei-Won Hide_Hide Hisumei_Hisumei 
-			Ho-Lee_Ho-Lee Ho-Ya_Ho-Ya Ho_Ho Hong_Hong Hope_Hope Hou-Ting_Hou-Ting Hou-Yan_Hou-Yan Hou_Hou 
-			Ichiko_Ichiko Im-Lee_Im-Lee Ipek_Ipek Iris_Iris Isami_Izumi Ivy_Ivy Jasmine_Jasmine Ji_Ji 
-			Jia_Jia Jiangnu_Jiangnu Jin_Jin Jira_Jira Jiuge_Jiuge Jojo_Jojo Joo-Dee_Joo-Dee Ju-Lee_Ju-Lee 
-			Ju_Ju Jun-Pu_Jun-Pu Jun_Jun June_June Kai-Lee_Kai-Lee Kait-Lin_Kait-Lin Kaya_Kaya Ke-Lee_Ke-Lee 
-			Kei_Kei Keiri_Keiri Khogaghchin_Khogaghchin Khulan_Khulan Kikyo_Kikyo Kim-Lee_Kim-Lee Kirei_Kirei Koko_Koko 
-			Konata_Konata Kori_Kori Koto_Koto Kotobuki_Kotobuki Kuvira_Kuvira Kyoshi_Kyoshi Lan-Xin_Lan-Xin Lan_Lan 
-			Le-Ah_Le-Ah Lee-An_Lee-An Lee-Han_Lee-Han Lee-Lee_Lee-Lee Lee-Pu_Lee-Pu Lee-Wei_Lee-Wei Lee-Yan_Lee-Yan Lee-hou_Lee-hou 
-			Lee_Lee Lei-An_Lei-An Lei_Lei Li_Li Lian_Lian Liang_Liang Lien_Lien Lilac_Lilac 
-			Liling_Liling Lily-Ling_Lily-Ling Lily_Lily Lin-Lin_Lin-Lin Lin_Lin Lina_Lina Ling-Ling_Ling-Ling Ling-Min_Ling-Min 
-			Ling-Wei_Ling-Wei Ling_Ling Liu-Liu_Liu-Liu Liu_Liu Lo_Lo Lokai_Lokai Lu-Chu_Lu-Chu Lubugu_Lubugu 
-			Macmu-Ling_Macmu-Ling Magnolia_Magnolia Mah_Mah Makh_Makh Marigold_Marigold Meel-Itza_Meel-Itza Megumi_Megumi Mei-Lee_Mei-Lee 
-			Mei-Xing_Mei-Xing Mei_Mei Meng-Meng_Meng-Meng Meng_Meng Mi-Ah_Mi-Ah Mikasa_Mikasa Min-Lee_Min-Lee Min_Min 
-			Mitsu_Mitsu Miyabi_Miyabi Miyako_Miyako Mo-Lee_Mo-Lee Mo-Li_Mo-Li Mo-Song_Mo-Song Na-Ai_Na-Ai Na-An_Na-An 
-			Nana_Nana Nanai_Nanai Nanaidhat_Nanaidhat Naoki_Naoki Nat-Lee_Nat-Lee Navvaba_Navvaba Nazilla_Nasilla Nomolun_Nomolun 
-			Nosumi_Nozumi Nuan-Fen_Nuan-Fen Nuan_Nuan Oma_Oma Opal_Opal Orchid_Orchid Pansy_Pansy Parvin_Parvin 
-			Pema_Pema Peng_Peng Penga_Penga Peony_Peony Po-Lee_Po-Lee Ponyo_Ponyo Poppy_Poppy Pu_Pu 
-			Pusuwan_Pusuwan Qi_Qi Rani_Rani Ranisa_Ranisa Riza_Riza Rizua_Rizua Rong_Rong Roxana_Roxana 
-			Ru_Ru Rui-Yun_Rui-Yun Rui_Rui Sai_Sai Saige_Saige Sakae_Sakae Sari_Sari Sato_Sato 
-			Sei_Sei Sela_Sela Senna_Senna Shan_Shan Shayn_Shayn Shige_Shige Shiori_Shiori Shirin_Shirin 
-			Shu-Fang_Shu-Fang Shu_Shu Shulu-Ping_Shulu-Ping Shun_Shun Shuogu_Shuogu Sokhatai_Sokhatai Song-An_Song-An Song-Fan_Song-Fan 
-			Song-Lee_Song-Lee Song_Song Star_Star Stei-See_Stei-See Su_Su Suki_Suki Sum-Ting-Rong_Sum-Ting-Rong Suyin_Suyin 
-			Tabuyan_Tabuyan Tae_Tae Tai-Yue_Tai-Yue Tai_Tai Taige_Taige Taoge_Taoge Tati_Tati Ting_Ting 
-			Tomo_Tomo Tomoe_Tomoe Toph_Toph Touran_Touran Tsukasa_Tsukasa Tu-Lee_Tu-Lee Tu-Ling_Tu-Ling Tu_Tu 
-			Tura_Tura Tuyen_Tuyen Ty-Lee_Ty-Lee Ula_Ula Umi_Umi Uta_Uta Vina_Vina Violet_Violet 
-			Watari_Watari Wei-Lee_Wei-Lee Wei_Wei Wen-Yen_Wen-Yen Won-Yee_Won-Yee Wu_Wu Xia_Xia Xiao-Wen_Xiao-Wen 
-			Xiao_Xiao Xin-Xin_Xin-Xin Xin_Xin Xing-Ying_Xing-Ying Xing_Xing Xingge_Xingge Xingke_Xingke Xue_Xue 
-			Ya-Rong_Ya-Rong Ya-Wei_Ya-Wei Ya_Ya Yan_Yan Yange_Yange Yanmu_Yanmu Yasaman_Yasaman Yasar_Yasar 
-			Yasuko_Yasuko Yee-Li_Yee-Li Yen_Yen Yena_Yena Yesugun_Yesugun Yin_Yin Ying_Ying Yingtian_Yingtian 
-			Yoiko_Yoiko Yong_Yong Yoshi_Yoshi Yue-Han_Yue-Han Yue-Lee_Yue-Lee Yue-Yun_Yue-Yun Yue_Yue Yugito_Yugito 
-			Yume_Yume Yun_Yun Yuu_Yuu Zamara_Zamara Zo-He_Zo-He
+			Adi Aeko Ageha Ah-Ho Ah Ahnah Ai-Laomay Ai 
+			Akira Alan Am-Lee-Ah An-Ah An-Lee An-ji An Ansu_Anzu 
+			Asami Ash-Lee Asusako Aya
+			Bage Bao-Lee Bao Biming 
+			Blossom Boshi Botokhui Bunko Buttercup Chabi Chang Changshou 
+			Chaogui Chen-Ah Chen-Chun Chen-Lee Chen Chi-Chi Chi-Tai Chi 
+			Chin Ching-Lan Chise Chong-Lee Chotan Chu-hua Chun-Lee Chun-Pu 
+			Chun Clover Cong-Ho Cong Cuiba 
+			Dahlia Daisy_Daisy Dao-Han 
+			Dao-Lee Dao-ming Dawei Dianni 
+			Eh-Rin Ei-Dee Em-Lee 
+			Fa-Fen Fa-Lee Fa-Lin Fa-Song Fa Fan-Fan Fan-Fen Fan-He Fan 
+			Fang Feiyan Fen-Fen Fen-Violet Fen Feng-Shu Fu-Chi Fu-Ji
+			Fu Fuku Fumi Fuse Fuuko Fuutaba 
+			Hail-Lee Han-Wei 
+			Han Hang-Lee Hang Haruka He-Qi Hei-Won Hide Hisumei 
+			Ho-Lee Ho-Ya Ho Hong Hope Hou-Ting Hou-Yan Hou 
+			Ichiko Im-Lee Ipek Iris Isami_Izumi Ivy 
+			Jasmine Ji Jia Jiangnu Jin Jira Jiuge Jojo Joo-Dee Ju-Lee 
+			Ju Jun-Pu Jun June 
+			Kai-Lee Kait-Lin Kaya Ke-Lee 
+			Kei Keiri Khogaghchin Khulan Kikyo Kim-Lee Kirei Koko 
+			Konata Kori Koto Kotobuki Kuvira Kyoshi 
+			Lan-Xin Lan Le-Ah Lee-An Lee-Han Lee-Lee Lee-Pu Lee-Wei Lee-Yan Lee-hou 
+			Lee Lei-An Lei Li Lian Liang Lien Lilac 
+			Liling Lily-Ling Lily Lin-Lin Lin Lina Ling-Ling Ling-Min 
+			Ling-Wei Ling Liu-Liu Liu Lo Lokai Lu-Chu Lubugu 
+			Macmu-Ling Magnolia Mah Makh Marigold Meel-Itza Megumi Mei-Lee 
+			Mei-Xing Mei Meng-Meng Meng Mi-Ah Mikasa Min-Lee Min 
+			Mitsu Miyabi Miyako Mo-Lee Mo-Li Mo-Song 
+			Na-Ai Na-An ana Nanai Nanaidhat Naoki Nat-Lee Navvaba Nazilla Nomolun 
+			Nosumi_Nozumi Nuan-Fen Nuan 
+			Oma Opal Orchid 
+			Pansy Parvin Pema Peng Penga Peony Po-Lee Ponyo Poppy Pu 
+			Pusuwan 
+			Qi 
+			Rani Ranisa Riza Rizua Rong Roxana 
+			Ru Rui-Yun Rui 
+			Sai Saige Sakae Sari Sato 
+			Sei Sela Senna Shan Shayn Shige Shiori Shirin 
+			Shu-Fang Shu Shulu-Ping Shun Shuogu Sokhatai Song-An Song-Fan
+			Song-Lee Song Star Stei-See Su Suki Sum-Ting-Rong Suyin 
+			Tabuyan Tae Tai-Yue Tai Taige Taoge Tati Ting 
+			Tomo Tomoe Toph Touran Tsukasa Tu-Lee Tu-Ling Tu 
+			Tura Tuyen Ty-Lee 
+			Ula Umi Uta 
+			Vina Violet 
+			Watari Wei-Lee Wei Wen-Yen Won-Yee Wu 
+			Xia Xiao-Wen 
+			Xiao Xin-Xin Xin Xing-Ying Xing Xingge Xingke Xue 
+			Ya-Rong Ya-Wei Ya Yan Yange Yanmu Yasaman Yasar 
+			Yasuko Yee-Li Yen Yena Yesugun Yin Ying Yingtian 
+			Yoiko Yong Yoshi Yue-Han Yue-Lee Yue-Yun Yue Yugito 
+			Yume Yun Yuu 
+			Zamara Zo-He
 		}
 		
 		dukes_called_kings = no
@@ -520,99 +543,120 @@ earth_kingdom_culture = {
 		color = { 20 140 39 }
 		
 		male_names = {
-			Abaoji_Abaoji Aiwei_Aiwei Akisada_Akisada Akitakai_Akitaka Akitsune_Akitsune Alp_Alp Anxi_Anxi Ao-Bang_Ao-Bang 
-			Ao_Ao Aoda_Aoda Arik_Arik Baatar_Baatar Bai-Kong_Bai-Kong Bai_Bai Bang_Bang Bei_Bei 
-			Biegute_Biegute Bishe_Bishe Blush_Blush Bo-Bee_Bo-Bee Bo-Bi_Bo-Bi Bo-Bo_Bo-Bo Bo-Lee_Bo-Lee Bo-Rei_Bo-Rei 
-			Bo_Bo Bohai_Bohai Bolin_Bolin Brei-Dee_Brei-Dee Bumi_Bumi Bushi_Bushi Butakha_Butakha Buwei_Buwei 
-			Cao-Cao_Cao-Cao Cao-Dee_Cao-Dee Cao_Cao Chanai_Chanai Changdong_Changdong Chao_Chao Cheng_Cheng Chin_Chin 
-			Chong_Chong Chow_Chow Chung_Chung Cong_Cong Da-Lee_Da-Lee Da_Da Dai-Lee_Dai-Lee Dai_Dai 
-			Daquan_Daquan Dashi_Dashi Daw_Daw Deguang_Deguang Deming_Deming Dilie_Dilie Dong-Long_Dong-Long Dong-Min_Dong-Min 
-			Dong_Dong Du-Ho_Du-Ho Duolubu_Duolubu Eh-Dee_Eh-Dee Fai_Fai Fang_Fang Fei_Fei Feng-Long_Feng-Long 
-			Feng_Feng Fong_Fong Fu_Fu Fugazhi_Fugazhi Fuguzhi_Fuguzhi Fuling-Ji_Fuling-Ji Fuling_Fuling Fung_Fung 
-			Gai-Ree_Gai-Ree Ganbat_Ganbat Gang_Gang Gansu_Gansu Gao_Gao Gaye_Gaye Ghazan_Ghazan Godan_Godan 
-			Gommu_Gommu Gopala_Gopala Gorota_Gorota Gou'er_Gou'er Gow_Gow Gsi_Gzi Guang_Guang Gun_Gun 
-			Guo_Guo Hai_Hai Harghasun_Harghasun Harjjaravarman_Harjjaravarman Haru_Haru Haruie_Haruie Harumasa_Harumasa He-Long_He-Long 
-			He_He Heng_Heng Hiroshi_Hiroshi Ho-Tun_Ho-Tun Ho_Ho Hokai_Hokai Hong-Lee_Hong-Li Hong_Hong 
-			Hongji_Hongji Hougu_Hougu How_How Hu-Hai_Hu-Hai Huan_Huan Hung_Hung Hyo_Hyo Hyuga_Hyuga 
-			Hyun_Hyun Ieharu_Ieharu Iemune_Iemune Jae_Jae Jai-Ree_Jai-Ree Jai_Jai Jebe_Jebe Jet_Jet 
-			Ji-Jia_Ji-Jia Ji_Ji Jia_Jia Jian_Jian Jiao-Long_Jiao-Long Jie_Jie Jin-Wei_Jin-Wei Jin_Jin 
-			Jing_Jing Jingbo_Jingbo Jochi_Jochi Ju-Long_Ju-Long Ju-Min_Ju-Min Ju-Wei_Ju-Wei Ju-si_Ju-si Ju_Ju 
-			Jung_Jung Juno_Juno Kai_Kai Kaili_Kaili Kang-Cong_Kang-Cong Kang_Kang Kanto_Kanto Karu_Karu 
-			Kasuki_Kazuki Kei-See_Kei-See Kenji_Kenji Ketuyu_Ketuyu Keung_Keung Khal_Khal Ki_Ki Kim-Lee_Kim-Lee 
-			Kim_Kim Kokochu_Kokochu Kong_Kong Kopti_Kopti Kosa_Koza Kosel_Kozel Kuei_Kuei Kun_Kun 
-			Kuo-Yin_Kuo-Yin Kuo_Kuo Kuon_Kuon Kwan_Kwan Lao_Lao Laquan_Laquan Lee-Min_Lee-Min Lee-Shen_Lee-Shen 
-			Lee-Wei_Lee-Wei Lee_Lee Lei_Lei Li_Li Liang_Liang Lin-Yee_Lin-Yee Liu_Liu Long-Cheng_Long-Cheng 
-			Long-Dong_Long-Dong Long-Fai_Long-Fai Long-Fei_Long-Fei Long-Feng_Long-Feng Long-Shen_Long-Shen Long_Long Lu_Lu Lun-Quing_Lun-Quing 
-			Lun_Lun Luu-Kass_Luu-Kass Macao_Macao Mako_Mako Malu_Malu Mang_Mangokpok Masaharu_Masaharu Masanobu_Masanobu 
-			Megujin_Megujin Menggei_Menggei Min-Ho_Min-Ho Min-Ki_Min-Ki Min_Min Ming_Ming Moku_Moku Muneie_Muneie 
-			Muneuji_Muneuji Na_Na Nayaga_Nayaga Nobumaza_Nobumasa Nobuyasu_Nobuyasu Nogai_Nogai Noritame_Noritame Odchigin_Odchigin 
-			Oh_Oh Ohev_Ohev Okhotur_Okhotur Onku_Onku Otaku_Otaku Oyaji_Oyaji Pao_Pao Peng-Bo_Peng-Bo 
-			Peng-Lun_Peng-Lun Peng_Peng Ping-Bai_Ping-Bai Ping_Ping Poi_Poi Pong_Pong Pu-On-Tim_Pu-On-Tim Qi-Fu_Qi-Fu 
-			Qi_Qi Qian_Qian Qin_Qin Qing_Qing Quon_Quon Raiko_Raiko Ratnapala_Ratnapala Rian_Rian 
-			Ro-Bi_Ro-Bi Roi_Roi Ru_Ru Ruan-Jiang_Ruan-Jiang Ruan_Ruan Ryan_Ryan Ryu_Ryu Saikhan_Saikhan 
-			San_San Sang-Kyu_Sang-Kyu Sang-Min_Sang-Min Saru_Saru Satoru_Satoru Sensu_Sensu Sha-Wan_Sha-Wan She-Fu_She-Fu 
-			She-Tao_She-Tao She_She Shen-Fu_Shen-Fu Shen-Long_Shen-Long Shen-Ping_Shen-Ping Shen-Qi_Shen-Qi Shen-Ru_Shen-Ru Shen_Shen 
-			Sheng-She_Sheng-She Sheng_Sheng Shilugu_Zhilugu Shin_Shin Shinji_Shinji Shiro_Shiro Shu_Shu Si_Si 
-			Sokal_Sokal Songyuan_Zhongyuan Songzen_Songzan Sotan_Sotan Stei-Fen_Stei-Fen Su_Su Sud_Sud Sung_Sung 
-			Suogu_Suogu Suyiketu_Suyiketu Swami_Swami Tahn_Tahn Taku_Taku Tamenori_Tamenori Tao-Long_Tao-Long Tao-Xia_Tao-Xia 
-			Tao_Tao Temujin_Temujin Temur_Temur Teo_Teo Tian-Wei_Tian-Wei Tian_Tian Tiande_Tiande Todogen_Todogen 
-			Tolui_Tolui Tong_Tong Toza_Toza Tsuneaki_Tsuneaki Tu_Tu Tugor_Tugor Tumen_Tumen Tycho_Tycho 
-			Tyro_Tyro Uge_Uge Uji_Ujimune Ukhuna_Ukhuna Usluk_Uzluk Usur_Uzur Vijaya_Vijaya Wan_Wan 
-			Wang-Long_Wang-Long Wang_Wang Wei-Jin_Wei-Jin Wei-Li_Wei-Li Wei_Wei Wen_Wen Wenshunu_Wenshunu Wing_Wing 
-			Wolila_Wolila Wu_Wu Wuge_Wuge Wuyu_Wuyu Xai-Bau_Xai-Bau Xai_Xai Xian-Lee_Xian-Lee Xian_Xian 
-			Xie-Chao_Xie-Chao Xie-Tao_Xie-Tao Xie_Xie Xin-Fu_Xin-Fu Xin_Xin Xing_Xing Xingke_Xingke Xiuge_Xiuge 
-			Xun_Xun Yanchege_Yanchege Yang-Yu_Yang-Yu Yang_Yang Yanxi_Yanxi Yashi_Yashi Yasunobu_Yasunobu Yedi_Yedi 
-			Yegu_Yegu Yeke_Yeke Yi-Ming_Yi-Ming Yi-Tian_Yi-Tian Yi_Yi Yie-Bei_Yie-Bei Yilie_Yilie Yin-Lee_Yin-Lee 
-			Yin-Long_Yin-Long Yin_Yin Ying-Yu_Ying-Yu Ying_Ying Yoh_Yoh Yong-Fang_Yong-Fang Yong-Min_Yong-Min Yong_Yong 
-			Young_Young Yu-Yu_Yu-Yu Yu_Yu Yuan_Yuan Yun-Lee_Yun-Lee Yun_Yun Yung_Yung Yuu_Yuu 
-			Zaheer_Zaheer Zei_Zei
+			Abaoji Aiwei Akisada Akitakai Akitsune Alp Anxi Ao-Bang 
+			Ao Aoda Arik 
+			Baatar Bai-Kong Bai Bang Bei 
+			Biegute Bishe Blush Bo-Bee Bo-Bi Bo-Bo Bo-Lee Bo-Rei 
+			Bo Bohai Bolin Brei-Dee Bumi Bushi Butakha Buwei 
+			Cao-Cao Cao-Dee Cao Chanai Changdong Chao Cheng Chin 
+			Chong Chow Chung Cong 
+			Da-Lee Da Dai-Lee Dai
+			Daquan Dashi Daw Deguang Deming Dilie Dong-Long Dong-Min 
+			Dong Du-Ho Duolubu 
+			Eh-Dee 
+			Fai Fang Fei Feng-Long 
+			Feng Fong Fu Fugazhi Fuguzhi Fuling-Ji Fuling Fung 
+			Gai-Ree Ganbat Gang Gansu Gao Gaye Ghazan Godan 
+			Gommu Gopala Gorota Gou'er Gow Gsi_Gzi Guang Gun 
+			Guo 
+			Hai Harghasun Harjjaravarman Haru Haruie Harumasa He-Long 
+			He Heng Hiroshi Ho-Tun Ho Hokai Hong-Lee_Hong-Li Hong 
+			Hongji Hougu How Hu-Hai Huan Hung Hyo Hyuga 
+			Hyun 
+			Ieharu Iemune Jae Jai-Ree Jai Jebe Jet 
+			Ji-Jia Ji Jia Jian Jiao-Long Jie Jin-Wei Jin
+			Jing Jingbo Jochi Ju-Long Ju-Min Ju-Wei Ju-si Ju
+			Jung Juno 
+			Kai Kaili Kang-Cong Kang Kanto Karu 
+			Kasuki_Kazuki Kei-See Kenji Ketuyu Keung Khal Ki Kim-Lee 
+			Kim Kokochu Kong Kopti Kosa Kosel_Kozel Kuei Kun 
+			Kuo-Yin Kuo Kuon Kwan 
+			Lao Laquan Lee-Min Lee-Shen 
+			Lee-Wei Lee Lei Li Liang Lin-Yee Liu Long-Cheng 
+			Long-Dong Long-Fai Long-Fei Long-Feng Long-Shen Long Lu Lun-Quing 
+			Lun Luu-Kass 
+			Macao Mako Malu Mang Masaharu Masanobu
+			Megujin Menggei Min-Ho Min-Ki Min Ming Moku Muneie 
+			Muneuji 
+			Na Nayaga Nobumaza_Nobumasa Nobuyasu Nogai Noritame 
+			Odchigin 
+			Oh Ohev Okhotur Onku Otaku Oyaji 
+			Pao Peng-Bo 
+			Peng-Lun Peng Ping-Bai Ping Poi Pong Pu-On-Tim Qi-Fu 
+			Qi Qian Qin Qing Quon
+			Raiko Ratnapala Rian 
+			Ro-Bi Roi Ru Ruan-Jiang Ruan Ryan Ryu 
+			Saikhan 
+			San Sang-Kyu Sang-Min Saru Satoru Sensu Sha-Wan She-Fu 
+			She-Tao She Shen-Fu Shen-Long Shen-Ping Shen-Qi Shen-Ru Shen 
+			Sheng-She Sheng Shilugu_Zhilugu Shin Shinji Shiro Shu Si 
+			Sokal Songyuan_Zhongyuan Songzen_Songzan Sotan Stei-Fen Su Sud Sung 
+			Suogu Suyiketu Swami 
+			Tahn Taku Tamenori Tao-Long Tao-Xia 
+			Tao Temujin Temur Teo Tian-Wei Tian Tiande Todogen 
+			Tolui Tong Toza Tsuneaki Tu Tugor Tumen Tycho 
+			Tyro 
+			Uge Uji_Ujimune Ukhuna Usluk_Uzluk Usur_Uzur 
+			Vijaya 
+			Wan Wang-Long Wang Wei-Jin Wei-Li Wei Wen Wenshunu Wing 
+			Wolila Wu Wuge Wuyu 
+			Xai-Bau Xai Xian-Lee Xian 
+			Xie-Chao Xie-Tao Xie Xin-Fu Xin Xing Xingke Xiuge 
+			Xun 
+			Yanchege Yang-Yu Yang Yanxi Yashi Yasunobu Yedi 
+			Yegu Yeke Yi-Ming Yi-Tian Yi Yie-Bei Yilie Yin-Lee 
+			Yin-Long Yin Ying-Yu Ying Yoh Yong-Fang Yong-Min Yong 
+			Young Yu-Yu Yu Yuan Yun-Lee Yun Yung Yuu 
+			Zaheer Zei
 		}
 		female_names = {
-			Adi_Adi Ae_Ae Aeko_Aeko Ah-Ho_Ah-Ho Ah_Ah Ahnah_Ahnah Ai-Laomay_Ai-Laomay Ai_Ai 
-			Akira_Akira Alan_Alan Am-Lee-Ah_Am-Lee-Ah An-Ah_An-Ah An-Lee_An-Lee An-ji_An-ji An_An Asami_Asami 
-			Ash-Lee_Ash-Lee Asusako_Asusako Aya_Aya Bage_Bage Bao-Lee_Bao-Lee Bao_Bao Biming_Biming Blossom_Blossom 
-			Boshi_Boshi Botokhui_Botokhui Bunko_Bunko Buttercup_Buttercup Chabi_Chabi Chang_Chang Changshou_Changshou Chaogui_Chaogui 
-			Chen-Ah_Chen-Ah Chen-Chun_Chen-Chun Chen-Lee_Chen-Lee Chen_Chen Chi-Chi_Chi-Chi Chi-Tai_Chi-Tai Chi_Chi Chin_Chin 
-			Ching-Lan_Ching-Lan Chong-Lee_Chong-Lee Chotan_Chotan Chu-hua_Chu-hua Chun-Hei_Chun-Hei Chun-Lee_Chun-Lee Chun-Pu_Chun-Pu Chun_Chun 
-			Clover_Clover Cong-Ho_Cong-Ho Cong_Cong Cuiba_Cuiba Dahlia_Dahlia Daisy_Daisy Dao-Han_Dao-Han Dao-Lee_Dao-Lee 
-			Dao-ming_Dao-ming Dawei_Dawei Dianni_Dianni Eh-Rin_Eh-Rin Ei-Dee_Ei-Dee Em-Lee_Em-Lee Eun-Mi_Eun-Mi Eun-Sun_Eun-Sun 
-			Eun_Eun Fa-Fen_Fa-Fen Fa-Lee_Fa-Lee Fa-Lin_Fa-Lin Fa-Song_Fa-Song Fa_Fa Fan-Fan_Fan-Fan Fan-Fen_Fan-Fen 
-			Fan-He_Fan-He Fan_Fan Fang_Fang Feiyan_Feiyan Fen-Fen_Fen-Fen Fen-Violet_Fen-Violet Fen_Fen Feng-Shu_Feng-Shu 
-			Fu-Chi_Fu-Chi Fu-Ji_Fu-Ji Fu_Fu Fuku_Fuku Fumi_Fumi Fuse_Fuse Fuuko_Fuuko Fuutaba_Fuutaba 
-			Hail-Lee_Hail-Lee Han-Wei_Han-Wei Han_Han Hana_Hana Hang-Lee_Hang-Lee Hang_Hang Haruka_Haruka He-Qi_He-Qi 
-			Hei-Won_Hei-Won Hide_Hide Hisumei_Hisumei Ho-Lee_Ho-Lee Ho-Ya_Ho-Ya Ho_Ho Hong_Hong Hope_Hope 
-			Hou-Ting_Hou-Ting Hou-Yan_Hou-Yan Hou_Hou Ichiko_Ichiko Im-Lee_Im-Lee Ipek_Ipek Iris_Iris Ivy_Ivy 
-			Jae_Jae Jasmine_Jasmine Ji_Ji Jia_Jia Jiangnu_Jiangnu Jin_Jin Jira_Jira Jiuge_Jiuge 
-			Jojo_Jojo Joo-Dee_Joo-Dee Ju-Lee_Ju-Lee Ju_Ju Jun-Pu_Jun-Pu Jun_Jun June_June Kai-Lee_Kai-Lee 
-			Kait-Lin_Kait-Lin Kaya_Kaya Ke-Lee_Ke-Lee Kei_Kei Keiri_Keiri Khogaghchin_Khogaghchin Khulan_Khulan Kikyo_Kikyo 
-			Kim-Lee_Kim-Lee Kim_Kim Kirei_Kirei Koko_Koko Konata_Konata Kori_Kori Koto_Koto Kotobuki_Kotobuki 
-			Kuvira_Kuvira Kyoshi_Kyoshi Lan-Xin_Lan-Xin Lan_Lan Le-Ah_Le-Ah Lee-An_Lee-An Lee-Han_Lee-Han Lee-Lee_Lee-Lee 
-			Lee-Pu_Lee-Pu Lee-Wei_Lee-Wei Lee-Yan_Lee-Yan Lee-hou_Lee-hou Lee_Lee Lei-An_Lei-An Lei_Lei Li_Li 
-			Lian_Lian Liang_Liang Lien_Lien Lihua_Lihua Lilac_Lilac Liling_Liling Lily-Ling_Lily-Ling Lily_Lily 
-			Lin-Lin_Lin-Lin Lin_Lin Lina_Lina Ling-Ling_Ling-Ling Ling-Min_Ling-Min Ling-Wei_Ling-Wei Ling_Ling Liu-Liu_Liu-Liu 
-			Liu_Liu Lo_Lo Lokai_Lokai Lu-Chu_Lu-Chu Lubugu_Lubugu Macmu-Ling_Macmu-Ling Magnolia_Magnolia Mah_Mah 
-			Makh_Makh Marigold_Marigold Meel-Itza_Meel-Itza Megumi_Megumi Mei-Lee_Mei-Lee Mei-Xing_Mei-Xing Mei_Mei Meng-Meng_Meng-Meng 
-			Meng_Meng Mi-Ah_Mi-Ah Mi-Hi_Mi-Hi Mi-Sun_Mi-Sun Micha_Micha Mikasa_Mikasa Min-Jee_Min-Jee Min-Lee_Min-Lee 
-			Min_Min Misun_Misun Mitsu_Mitsu Miyabi_Miyabi Miyako_Miyako Mo-Lee_Mo-Lee Mo-Li_Mo-Li Mo-Song_Mo-Song 
-			Myung_Myung Na-Ai_Na-Ai Na-An_Na-An Na_Na Nana_Nana Nanai_Nanai Nanaidhat_Nanaidhat Naoki_Naoki 
-			Nat-Lee_Nat-Lee Navvaba_Navvaba Nazilla_Nasilla Nomolun_Nomolun Nosumi_Nozumi Nuan-Fen_Nuan-Fen Nuan_Nuan Ny_Ny 
-			Oma_Oma Opal_Opal Orchid_Orchid Pansy_Pansy Parvin_Parvin Pema_Pema Peng_Peng Penga_Penga 
-			Peony_Peony Po-Lee_Po-Lee Ponyo_Ponyo Poppy_Poppy Pu_Pu Pusuwan_Pusuwan Qi_Qi Rani_Rani 
-			Ranisa_Ranisa Riza_Riza Rizua_Rizua Rong_Rong Roxana_Roxana Ru_Ru Rui-Yun_Rui-Yun Rui_Rui 
-			Sai_Sai Saige_Saige Sakae_Sakae Sang-Hee_Sang-Hee Sari_Sari Sato_Sato Sei_Sei Sela_Sela 
-			Senna_Senna Seon_Seon Shan_Shan Shayn_Shayn Shengtong_Shengtong Shige_Shige Shiori_Shiori Shirin_Shirin 
-			Shu-Fang_Shu-Fang Shu_Shu Shulu-Ping_Shulu-Ping Shun_Shun Shuogu_Shuogu So-Young_So-Young Sokhatai_Sokhatai Song-An_Song-An 
-			Song-Fan_Song-Fan Song-Lee_Song-Lee Song_Song Soo-Jin_Soo-Jin Soo-Min_Soo-Min Soo-Yun_Soo-Yun Soon-Bok_Soon-Bok Star_Star 
-			Stei-See_Stei-See Su_Su Sue-Si_Shu-Zi Suki_Suki Sum-Ting-Rong_Sum-Ting-Rong Sun_Sun Suyin_Suyin Tabuyan_Tabuyan 
-			Tae_Tae Tai-Yue_Tai-Yue Tai_Tai Taige_Taige Taoge_Taoge Tati_Tati Ting_Ting Tomo_Tomo 
-			Tomoe_Tomoe Toph_Toph Touran_Touran Tsukasa_Tsukasa Tsuki_Tsuki Tu-Lee_Tu-Lee Tu-Ling_Tu-Ling Tu_Tu 
-			Tura_Tura Tuyen_Tuyen Ty-Lee_Ty-Lee Ula_Ula Umi_Umi Uta_Uta Vina_Vina Violet_Violet 
-			Wei-Lee_Wei-Lee Wei_Wei Wen-Yen_Wen-Yen Won-Yee_Won-Yee Wu_Wu Xia_Xia Xiao-Wen_Xiao-Wen Xiao_Xiao 
-			Xin-Xin_Xin-Xin Xin_Xin Xing-Ying_Xing-Ying Xing_Xing Xingge_Xingge Xingke_Xingke Xue_Xue Ya-Rong_Ya-Rong 
-			Ya-Wei_Ya-Wei Ya_Ya Yan_Yan Yange_Yange Yanmu_Yanmu Yasaman_Yasaman Yasar_Yasar Yasuko_Yasuko 
-			Yee-Li_Yee-Li Yen_Yen Yena_Yena Yesugun_Yesugun Yin_Yin Ying_Ying Yingtian_Yingtian Yoiko_Yoiko 
-			Yong_Yong Yoshi_Yoshi Young-Mi_Young-Mi Yue-Han_Yue-Han Yue-Lee_Yue-Lee Yue-Yun_Yue-Yun Yue_Yue Yugito_Yugito 
-			Yume_Yume Yun_Yun Yuu_Yuu Zamara_Zamara Zo-He_Zo-He
+			Adi Ae Aeko Ah-Ho Ah Ahnah Ai-Laomay Ai 
+			Akira Alan Am-Lee-Ah An-Ah An-Lee An-ji An Asami 
+			Ash-Lee Asusako Aya Bage Bao-Lee Bao Biming Blossom 
+			Boshi Botokhui Bunko Buttercup Chabi Chang Changshou Chaogui 
+			Chen-Ah Chen-Chun Chen-Lee Chen Chi-Chi Chi-Tai Chi Chin 
+			Ching-Lan Chong-Lee Chotan Chu-hua Chun-Hei Chun-Lee Chun-Pu Chun 
+			Clover Cong-Ho Cong Cuiba Dahlia Daisy Dao-Han Dao-Lee 
+			Dao-ming Dawei Dianni Eh-Rin Ei-Dee Em-Lee Eun-Mi Eun-Sun 
+			Eun Fa-Fen Fa-Lee Fa-Lin Fa-Song Fa Fan-Fan Fan-Fen 
+			Fan-He Fan Fang Feiyan Fen-Fen Fen-Violet Fen Feng-Shu 
+			Fu-Chi Fu-Ji Fu Fuku Fumi Fuse Fuuko Fuutaba 
+			Hail-Lee Han-Wei Han Hana Hang-Lee Hang Haruka He-Qi 
+			Hei-Won Hide Hisumei Ho-Lee Ho-Ya Ho Hong Hope 
+			Hou-Ting Hou-Yan Hou Ichiko Im-Lee Ipek Iris Ivy 
+			Jae Jasmine Ji Jia Jiangnu Jin Jira Jiuge 
+			Jojo Joo-Dee Ju-Lee Ju Jun-Pu Jun June Kai-Lee 
+			Kait-Lin Kaya Ke-Lee Kei Keiri Khogaghchin Khulan Kikyo 
+			Kim-Lee Kim Kirei Koko Konata Kori Koto Kotobuki 
+			Kuvira Kyoshi Lan-Xin Lan Le-Ah Lee-An Lee-Han Lee-Lee 
+			Lee-Pu Lee-Wei Lee-Yan Lee-hou Lee Lei-An Lei Li
+			Lian Liang Lien Lihua Lilac Liling Lily-Ling Lily 
+			Lin-Lin Lin Lina Ling-Ling Ling-Min Ling-Wei Ling Liu-Liu 
+			Liu Lo Lokai Lu-Chu Lubugu Macmu-Ling Magnolia Mah 
+			Makh Marigold Meel-Itza Megumi Mei-Lee Mei-Xing Mei Meng-Meng 
+			Meng Mi-Ah Mi-Hi Mi-Sun Micha Mikasa Min-Jee Min-Lee 
+			Min Misun Mitsu Miyabi Miyako Mo-Lee Mo-Li Mo-Song 
+			Myung 
+			Na-Ai Na-An Na Nana Nanai Nanaidhat Naoki 
+			Nat-Lee Navvaba Nazilla_Nasilla Nomolun Nosumi_Nozumi Nuan-Fen Nuan Ny 
+			Oma Opal Orchid Pansy Parvin Pema Peng Penga 
+			Peony Po-Lee Ponyo Poppy Pu Pusuwan Qi Rani 
+			Ranisa Riza Rizua Rong Roxana Ru Rui-Yun Rui 
+			Sai Saige Sakae Sang-Hee Sari Sato Sei Sela 
+			Senna Seon Shan Shayn Shengtong Shige Shiori Shirin 
+			Shu-Fang Shu Shulu-Ping Shun Shuogu So-Young Sokhatai Song-An 
+			Song-Fan Song-Lee Song Soo-Jin Soo-Min Soo-Yun Soon-Bok Star 
+			Stei-See Su Sue-Si_Shu-Zi Suki Sum-Ting-Rong Sun Suyin Tabuyan 
+			Tae Tai-Yue Tai Taige Taoge Tati Ting Tomo 
+			Tomoe Toph Touran Tsukasa Tsuki Tu-Lee Tu-Ling Tu
+			Tura Tuyen Ty-Lee Ula Umi Uta Vina Violet 
+			Wei-Lee Wei Wen-Yen Won-Yee Wu_ Xia Xiao-Wen Xiao 
+			Xin-Xin Xin Xing-Ying Xing Xingge Xingke Xue Ya-Rong 
+			Ya-Wei Ya Yan Yange Yanmu Yasaman Yasar Yasuko 
+			Yee-Li Yen Yena Yesugun Yin Ying Yingtian Yoiko 
+			Yong Yoshi Young-Mi Yue-Han Yue-Lee Yue-Yun Yue Yugito
+			Yume Yun Yuu 
+			Zamara Zo-He
 		}
 
 		dukes_called_kings = no
@@ -2521,13 +2565,13 @@ air_nomad_culture = {
 			Aang-os_Aang-os Aang_Aang Afiko_Afiko Akar_Akar Anil_Anil Appa_Appa Assam_Assam Batu_Batu 
 			Boma_Boma Ceba_Ceba Champo_Champo Chanai_Chanai Choden_Choden Chogyal_Chogyal Chokey_Chokey Cimba_Cimba 
 			Dache_Dache Dachen_Dachen Daivika_Daivika Dawa_Dawa Dedan_Dedan Denpa_Denpa Denpo_Denpo Dhargey_Dhargey 
-			Dharmakame_Dharmakame Dharmasome_Dharmasome Dorje_Dorje Drub_Drub Drup_Drup Duga_Duga Fugazhi_Fugazhi Gardarinski_Gardarinski 
-			Garkan_Garkan Gaye_Gaye Gendun_Gendun Gephel_Gephel Goba_Goba Godan_Godan Gopala_Gopala Gyaltso_Gyaltso 
+			Dharmakame_Dharmakame Dharmasome_Dharmasome Dorje_Dorje Drub_Drub Drup_Drup Duga_Duga Fugazhi_Fugazhi  
+			Garkan_Garkan Gaye_Gaye Gendun_Gendun Gephel_Gephel Gesar Goba_Goba Godan_Godan Gopala_Gopala Gyaltso_Gyaltso 
 			Gyalwa_Gyalwa Gyatso_Gyatso Harjjaravarman_Harjjaravarman Hongji_Hongji Jalus_Jalus Jamphel_Jamphel Jampo_Jampo Jamyang_Jamyang 
-			Jangbu_Jangbu Jetsan_Jetsan Jigme_Jigme Jinju_Jinju Jinpa_Jinpa Kaba_Kaba Kalden_Kalden Kasa_Kasa 
-			Kelzang_Kelzang Ketu_Ketu Khedrup_Khedrup Kipu_Kipu Kitsi_Kitsi Kundun_Kundun Laghima_Laghima Lha-Mo_Lha-Mo 
+			Jangbu_Jangbu Jetsan_Jetsan Jigme_Jigme Jinju_Jinju Jinpa_Jinpa Kaba_Kaba Kalden_Kalden Kaigu Kasa_Kasa 
+			Kelzang_Kelzang Ketu_Ketu Khetuyu Khedrup_Khedrup Kipu_Kipu Kitsi_Kitsi Kundun_Kundun Laghima_Laghima Lha-Mo_Lha-Mo 
 			Lhak-Pa_Lhak-Pa Lhamo_Lhamo Lobsang_Lobsang Lungtok_Lungtok Meelo_Meelo Michewa_Michewa Mingma_Mingma Nawang_Nawang 
-			Ngawang_Ngawang Nobu_Nobu Norbu_Norbu Nuba_Nuba Nyima_Nyima Pabu_Pabu Palden_Palden Pasang_Pasang 
+			Ngawang_Ngawang Nincong Nobu_Nobu Norbu_Norbu Nuba_Nuba Nyima_Nyima Pabu_Pabu Palden_Palden Pasang_Pasang 
 			Phuntsok_Phuntsok Plazangpo_Plazangpo Po-Po_Po-Po Popo_Popo Poso_Poso Rabten_Rabten Rigsand_Rigsand Rinchen_Rinchen 
 			Rinzin_Rinzin Rohan_Rohan Samdup_Samdup Samten_Samten Sangye_Sangye Sashi_Sashi Schmi_Schmi Seba_Seba 
 			Shung_Shung Skamar_Skamar Sonam_Sonam Songzan_Songzan Sotan_Sotan Tang-Xu_Tang-Xu Tang_Tang Tashi_Tashi 
@@ -2539,7 +2583,7 @@ air_nomad_culture = {
 		female_names = {
 			Amala_Amala Amrita_Amrita Bage_Bage Boshi_Boshi Cepla_Cepla Changshou_Changshou Chaogui_Chaogui Chen_Chen 
 			Chesa_Chesa Chewa_Chewa Chime_Chime Choden_Choden Chomden_Chomden Como-Lung_Como-Lung Cuiba_Cuiba Dahlia_Dahlia 
-			Dawa_Dawa Denchen_Denchen Dhargey_Dhargey Dianni_Dianni Diki_Diki Dohna_Dohna Dolkar_Dolkar Dolma_Dolma 
+			Dawa_Dawa Daopo Denchen_Denchen Dhargey_Dhargey Dianni_Dianni Diki_Diki Dohna_Dohna Dolkar_Dolkar Dolma_Dolma 
 			Ekadzati_Ekadzati Garma_Garma Gawa_Gawa Geewa_Geewa Gokarmo_Gokarmo Gu-Lang_Gu-Lang Hariti_Hariti Ik_Ik 
 			Ikik_Ikik Ikki_Ikki Ikpa_Ikpa Indira_Indira Iris_Iris Jampa_Jampa Jamyang_Jamyang Jangmu_Jangmu 
 			Jinora_Jinora Jinpa_Jinpa Jiuge_Jiuge Juna-Pa_Juna-Pa Jungney_Jungney Karma_Karma Keyuri_Keyuri Kia_Kia 
@@ -2587,7 +2631,7 @@ air_nomad_culture = {
 			Aang-os_Aang-os Aang_Aang Afiko_Afiko Akar_Akar Anil_Anil Appa_Appa Assam_Assam Batu_Batu 
 			Boma_Boma Ceba_Ceba Champo_Champo Chanai_Chanai Choden_Choden Chogyal_Chogyal Chokey_Chokey Cimba_Cimba 
 			Dache_Dache Dachen_Dachen Daivika_Daivika Dawa_Dawa Dedan_Dedan Denpa_Denpa Denpo_Denpo Dhargey_Dhargey 
-			Dharmakame_Dharmakame Dharmasome_Dharmasome Dorje_Dorje Drub_Drub Drup_Drup Duga_Duga Fugazhi_Fugazhi Gardarinski_Gardarinski 
+			Dharmakame_Dharmakame Dharmasome_Dharmasome Dorje_Dorje Drub_Drub Drup_Drup Duga_Duga Fugazhi_Fugazhi  
 			Garkan_Garkan Gaye_Gaye Gendun_Gendun Gephel_Gephel Goba_Goba Godan_Godan Gopala_Gopala Gyaltso_Gyaltso 
 			Gyalwa_Gyalwa Gyatso_Gyatso Harjjaravarman_Harjjaravarman Hongji_Hongji Jalus_Jalus Jamphel_Jamphel Jampo_Jampo Jamyang_Jamyang 
 			Jangbu_Jangbu Jetsan_Jetsan Jigme_Jigme Jinju_Jinju Jinpa_Jinpa Kaba_Kaba Kalden_Kalden Kasa_Kasa 
@@ -2614,7 +2658,7 @@ air_nomad_culture = {
 			Ninguerre_Ninguerre Opame_Opame Palden_Palden Pansy_Pansy Pema_Pema Pemala_Pemala Penden_Penden Popo_Popo 
 			Poso_Poso Prabhavatigupta_Prabhavatigupta Pusuwan_Pusuwan Saige_Saige Sangmu_Sangmu Sengdroma_Sengdroma Sengmo_Sengmo Senna_Senna 
 			Shenden_Shenden Shige_Shige Shulu-Ping_Shulu-Ping Shuogu_Shuogu Sokhatai_Sokhatai Somba_Somba Tabuyan_Tabuyan Taige_Taige 
-			Tangdong_Tangdong Tango_Tango Taoge_Taoge Tara_Tara Tashi_Tashi Tho-Og_Tho-Og Ui_Ui Xiao-Wen_Xiao-Wen 
+			Tangdong_Tangdong Tango_Tango Taoge_Taoge Tara_Tara Tashi_Tashi Tho-Og_Tho-Og Tsongkha Ui_Ui Xiao-Wen_Xiao-Wen 
 			Xiao_Xiao Xingge_Xingge Yama_Yama Yang_Yang Yangchen_Yangchen Yange_Yange Yanmu_Yanmu Yingtian_Yingtian 
 			Yonten_Yonten Zenji_Zenji Zigsa_Zigsa Zonpa_Zonpa			 
 		}
@@ -2660,11 +2704,11 @@ air_nomad_culture = {
 			Kelzang_Kelzang Ketu_Ketu Khedrup_Khedrup Kipu_Kipu Kitsi_Kitsi Kundun_Kundun Laghima_Laghima Lha-Mo_Lha-Mo 
 			Lhak-Pa_Lhak-Pa Lhamo_Lhamo Lobsang_Lobsang Lungtok_Lungtok Meelo_Meelo Michewa_Michewa Mingma_Mingma Nawang_Nawang 
 			Ngawang_Ngawang Nobu_Nobu Norbu_Norbu Nuba_Nuba Nyima_Nyima Pabu_Pabu Palden_Palden Pasang_Pasang 
-			Phuntsok_Phuntsok Plazangpo_Plazangpo Po-Po_Po-Po Popo_Popo Poso_Poso Rabten_Rabten Rigsand_Rigsand Rinchen_Rinchen 
+			Phuntsok_Phuntsok Phuentsho Plazangpo_Plazangpo Po-Po_Po-Po Popo_Popo Poso_Poso Rabten_Rabten Rigsand_Rigsand Rinchen_Rinchen 
 			Rinzin_Rinzin Rohan_Rohan Samdup_Samdup Samten_Samten Sangye_Sangye Sashi_Sashi Schmi_Schmi Seba_Seba 
 			Shung_Shung Skamar_Skamar Sonam_Sonam Songzim_Songzan Sotan_Sotan Tang-Xu_Tang-Xu Tang_Tang Tashi_Tashi 
 			Temba_Temba Tenzin_Tenzin Tenzing_Tenzing Tenzo_Tenzo Thekchen_Thekchen Thubten_Thubten Tinley_Tinley Torma_Torma 
-			Trinley_Trinley Tsangyang_Tsangyang Tsering_Tsering Tseten_Tseten Tsomo_Tsomo Tsultrim_Tsultrim Wangdue_Wangdue Xu_Xu 
+			Trinley_Trinley Tsangyang_Tsangyang Tsering_Tsering Tseten_Tseten Tsomo_Tsomo Tsultrim_Tsultrim Ugyden Wangdue_Wangdue Wangchuck Xu_Xu 
 			Yanchege_Yanchege Yeke_Yeke Yeshe_Yeshe Yilie_Yilie Yongten_Yongten Yonten_Yonten Yoten_Yoten Zapa_Zapa 
 			Zopa_Zopa			 
 		}
@@ -2677,7 +2721,7 @@ air_nomad_culture = {
 			Jinora_Jinora Jinpa_Jinpa Jiuge_Jiuge Juna-Pa_Juna-Pa Jungney_Jungney Karma_Karma Keyuri_Keyuri Kia_Kia 
 			Kipu_Kipu Kitsi_Kitsi Kona_Kona Kurukulla_Kurukulla Lasya_Lasya Lhamu_Lhamu Lilac_Lilac Lily_Lily 
 			Lio_Lio Lubugu_Lubugu Magnolia_Magnolia Malu_Malu Marigold_Marigold Mida_Mida Nele_Nele Ninguerre_Ninguerre 
-			Opame_Opame Palden_Palden Pansy_Pansy Pema_Pema Pemala_Pemala Penden_Penden Popo_Popo Poso_Poso 
+			Opame_Opame Palden_Palden Pansy_Pansy Pema_Pema Pemala_Pemala Penden_Penden Penchen Phurma Popo_Popo Poso_Poso 
 			Prabhavatigupta_Prabhavatigupta Pusuwan_Pusuwan Saige_Saige Sangmu_Sangmu Sengdroma_Sengdroma Sengmo_Sengmo Senna_Senna Shenden_Shenden 
 			Shige_Shige Shulu-Ping_Shulu-Ping Shuogu_Shuogu Sokhatai_Sokhatai Somba_Somba Tabuyan_Tabuyan Taige_Taige Tangdong_Tangdong 
 			Tango_Tango Taoge_Taoge Tara_Tara Tashi_Tashi Tho-Og_Tho-Og Ui_Ui Xiao-Wen_Xiao-Wen Xiao_Xiao 


### PR DESCRIPTION
- Deleted repeated names from Ba Sing Se nameslist, more repeated names are a possibility in male Ba Sing Se list
- combined Ba Sing Se lists for male and female, alphabetized and integrated female
- cleaned up male, female names for Ba Sing Se, Northern Earth, Eastern Earth
- removed "Gardarinski" from Southern, Northern Air
- added a few Tangut, Central Tibetic names to Northern Air; a couple Bhutanese names to Southern Air